### PR TITLE
Update the link and attribution for GUAC

### DIFF
--- a/resources.md
+++ b/resources.md
@@ -87,7 +87,7 @@ The analysis phase involves how you use the SBOM, typically for compliance or se
 
 * [Cybellum](https://cybellum.com/) from Cybellum
 * [Dependency Track](https://dependencytrack.org/) from OWASP
-* [GUAC](https://github.com/guacsec/guac) from Kusari
+* [GUAC](https://guac.sh) from OpenSSF
 * [Helm](https://www.medcrypt.com/solutions/helm) from Medcrypt
 * [Open Source Vulnerabilities](https://osv.dev/) (OSV) from Google
 * [bomber](https://github.com/devops-kung-fu/bomber) from DKFM


### PR DESCRIPTION
Use the GUAC website instead of the GitHub repo.

Also update the attribution for GUAC, which is an OpenSSF incubating project, originally developed by Kusari, Google, Purdue University, and Citi.