### PR TITLE
Update FAQ: Plugins is now a standalone sidebar page

### DIFF
--- a/content/faq/how-do-i-enable-vulnerability-scanning.md
+++ b/content/faq/how-do-i-enable-vulnerability-scanning.md
@@ -1,8 +1,8 @@
 ---
 title: "How do I enable vulnerability scanning in sbomify?"
 description: "Guide to enabling vulnerability scanning in sbomify using Google OSV and Dependency Track, including plan availability and scan frequency."
-answer: "Enable the OSV plugin in your workspace plugin settings. It is available on all plans. Once enabled, SBOMs are scanned automatically on upload and periodically re-scanned. Dependency Track is available on Business and Enterprise plans."
-tldr: "Enable the OSV plugin in your workspace plugin settings. It is available on all plans. Once enabled, SBOMs are scanned automatically on upload and periodically re-scanned. Dependency Track is available on Business and Enterprise plans."
+answer: "Enable the OSV plugin from the Plugins page in your workspace sidebar. It is available on all plans. Once enabled, SBOMs are scanned automatically on upload and periodically re-scanned. Dependency Track is available on Business and Enterprise plans."
+tldr: "Enable the OSV plugin from the Plugins page in your workspace sidebar. It is available on all plans. Once enabled, SBOMs are scanned automatically on upload and periodically re-scanned. Dependency Track is available on Business and Enterprise plans."
 weight: 65
 keywords: [vulnerability scanning, OSV, Dependency Track, SBOM scanning, security scanning, sbomify vulnerabilities]
 url: /faq/how-do-i-enable-vulnerability-scanning/
@@ -16,9 +16,8 @@ url: /faq/how-do-i-enable-vulnerability-scanning/
 
 Vulnerability scanning is implemented as a plugin. To enable it:
 
-1. Navigate to your workspace **Settings**
-2. Go to the **Plugins** section
-3. Enable the **OSV** plugin (and/or **Dependency Track** if on a Business plan or above)
+1. Navigate to the **Plugins** page in your workspace sidebar
+2. Enable the **OSV** plugin (and/or **Dependency Track** if on a Business plan or above)
 
 Once enabled, any SBOM you upload is automatically scanned for known vulnerabilities. When you enable the plugin, recent SBOMs are also retroactively scanned.
 


### PR DESCRIPTION
## Summary
- Updated the vulnerability scanning FAQ to reflect that Plugins moved from a tab within Settings to its own standalone sidebar page
- Aligns with sbomify/sbomify#871

## Test plan
- [ ] Verify FAQ page renders correctly locally
- [ ] Confirm instructions match current UI navigation

🤖 Generated with [Claude Code](https://claude.com/claude-code)