### PR TITLE
Align FAQ walkthroughs with current screencasts

### DIFF
--- a/content/compliance/_index.md
+++ b/content/compliance/_index.md
@@ -49,6 +49,9 @@ Software Bill of Materials (SBOM) compliance requirements are rapidly evolving a
 - **[EU NIS2 Directive](/compliance/eu-nis2/)** - EU cybersecurity law for essential and important entities
   - _Who it affects:_ EU entities responsible for cybersecurity risk management and incident reporting
 
+- **[BSI TR-03183-2 (v2.1.0)](/compliance/bsi-tr-03183/)** - German Federal Office for Information Security technical guideline defining concrete SBOM format and content requirements aligned with the EU CRA
+  - _Who it affects:_ Manufacturers placing products with digital elements on the EU market, and vendors selling into German federal procurement
+
 ### UK Frameworks
 
 - **[Software Security Code of Practice (UK, May 2025)](/compliance/uk-software-security-code-of-practice/)** - Voluntary UK government code setting baseline secure software development, supply chain resilience, and customer communication expectations

--- a/content/compliance/bsi-tr-03183.md
+++ b/content/compliance/bsi-tr-03183.md
@@ -26,32 +26,32 @@ The current version is **v2.1.0** (2025-08-20). It is binding for German federal
 
 ## Format requirements (§4)
 
-| Requirement | Detail                                       |
-| ----------- | -------------------------------------------- |
-| Encoding    | JSON or XML                                  |
+| Requirement | Detail                                           |
+| ----------- | ------------------------------------------------ |
+| Encoding    | JSON or XML                                      |
 | Format      | CycloneDX v1.6 or later, OR SPDX v3.0.1 or later |
 
 ## SBOM-level required fields (§5.2.1)
 
-| Field            | Description                                          |
-| ---------------- | ---------------------------------------------------- |
-| Creator of SBOM  | Email address or URL identifying the SBOM author     |
-| Timestamp        | Date and time the SBOM was compiled                  |
+| Field           | Description                                      |
+| --------------- | ------------------------------------------------ |
+| Creator of SBOM | Email address or URL identifying the SBOM author |
+| Timestamp       | Date and time the SBOM was compiled              |
 
 ## Component-level required fields (§5.2.2)
 
-| Field                  | Description                                                              |
-| ---------------------- | ------------------------------------------------------------------------ |
-| Component creator      | Email address or URL                                                     |
-| Component name         | Name of the component                                                    |
-| Component version      | Version string, or RFC 3339 file modification date if no version exists  |
-| Filename               | Actual filename of the component (not a path)                            |
-| Dependencies           | Dependency relationships, with a completeness indicator                  |
-| Distribution licences  | SPDX identifiers or expressions                                          |
-| Hash                   | SHA-512 of the deployable component                                      |
-| Executable property    | Whether the component is executable                                      |
-| Archive property       | Whether the component is an archive                                      |
-| Structured property    | Whether the component is structured or unstructured                      |
+| Field                 | Description                                                             |
+| --------------------- | ----------------------------------------------------------------------- |
+| Component creator     | Email address or URL                                                    |
+| Component name        | Name of the component                                                   |
+| Component version     | Version string, or RFC 3339 file modification date if no version exists |
+| Filename              | Actual filename of the component (not a path)                           |
+| Dependencies          | Dependency relationships, with a completeness indicator                 |
+| Distribution licences | SPDX identifiers or expressions                                         |
+| Hash                  | SHA-512 of the deployable component                                     |
+| Executable property   | Whether the component is executable                                     |
+| Archive property      | Whether the component is an archive                                     |
+| Structured property   | Whether the component is structured or unstructured                     |
 
 ## Conditional fields - required if present (§5.2.3, §5.2.4)
 

--- a/content/compliance/bsi-tr-03183.md
+++ b/content/compliance/bsi-tr-03183.md
@@ -1,0 +1,90 @@
+---
+
+url: /compliance/bsi-tr-03183/
+title: "BSI TR-03183-2: SBOM Requirements (v2.1.0)"
+description: "Guide to the German Federal Office for Information Security (BSI) Technical Guideline TR-03183-2 v2.1.0, which defines SBOM format and content requirements aligned with the EU Cyber Resilience Act."
+section: compliance
+keywords: [BSI TR-03183, BSI TR-03183-2, BSI SBOM requirements, German SBOM standard, CRA SBOM technical guideline, BSI CycloneDX property taxonomy]
+---
+
+[← Back to Compliance Overview](/compliance/)
+
+**Who it affects:** Manufacturers placing products with digital elements on the EU market who need a concrete technical baseline for SBOM format and content. BSI TR-03183-2 is widely treated as the de facto reference for satisfying the [EU Cyber Resilience Act](/compliance/eu-cra/)'s SBOM expectations, especially for German federal procurement.
+
+<div class="cta-box">
+  <p><strong>Need help with compliance?</strong> We can help you navigate your SBOM compliance journey.</p>
+  <a href="https://app.sbomify.com/enterprise-contact/" class="cta-button">Get in Touch</a>
+</div>
+
+---
+
+## Overview
+
+The [BSI Technical Guideline TR-03183-2](https://bsi.bund.de/dok/TR-03183-en) ("Cyber Resilience Requirements - Part 2: SBOM"), published by Germany's Federal Office for Information Security (BSI), specifies the format and content of Software Bills of Materials. Where the [EU Cyber Resilience Act](/compliance/eu-cra/) tells manufacturers _that_ an SBOM is required, BSI TR-03183-2 spells out _what_ that SBOM must look like in practice.
+
+The current version is **v2.1.0** (2025-08-20). It is binding for German federal procurement and is increasingly referenced by EU-market vendors as a concrete baseline that aligns with CRA expectations.
+
+## Format requirements (§4)
+
+| Requirement | Detail                                       |
+| ----------- | -------------------------------------------- |
+| Encoding    | JSON or XML                                  |
+| Format      | CycloneDX v1.6 or later, OR SPDX v3.0.1 or later |
+
+## SBOM-level required fields (§5.2.1)
+
+| Field            | Description                                          |
+| ---------------- | ---------------------------------------------------- |
+| Creator of SBOM  | Email address or URL identifying the SBOM author     |
+| Timestamp        | Date and time the SBOM was compiled                  |
+
+## Component-level required fields (§5.2.2)
+
+| Field                  | Description                                                              |
+| ---------------------- | ------------------------------------------------------------------------ |
+| Component creator      | Email address or URL                                                     |
+| Component name         | Name of the component                                                    |
+| Component version      | Version string, or RFC 3339 file modification date if no version exists  |
+| Filename               | Actual filename of the component (not a path)                            |
+| Dependencies           | Dependency relationships, with a completeness indicator                  |
+| Distribution licences  | SPDX identifiers or expressions                                          |
+| Hash                   | SHA-512 of the deployable component                                      |
+| Executable property    | Whether the component is executable                                      |
+| Archive property       | Whether the component is an archive                                      |
+| Structured property    | Whether the component is structured or unstructured                      |
+
+## Conditional fields - required if present (§5.2.3, §5.2.4)
+
+- **SBOM-URI** - canonical URI of the SBOM document
+- **Source code URI** - location of the component's source code
+- **URI of deployable form** - location of the deployable artifact
+- **Other unique identifiers** - CPE, purl, etc.
+- **Original licences** - upstream licence declarations
+
+## Critical requirements
+
+- **No vulnerability data in the SBOM** (§3.1) - vulnerability information must be exchanged out-of-band (e.g. via VEX/VDR), not embedded in the SBOM itself.
+- **SPDX licence identifiers** (§6.1) - all licence values must use SPDX identifiers or expressions; free-form licence strings are not compliant.
+
+## Score uploaded SBOMs against the BSI checklist
+
+sbomify ships a **BSI TR-03183-2 v2.1.0** plugin that grades each uploaded SBOM against the format, SBOM-level, and component-level requirements above and surfaces the result on the SBOM detail page. Enable it from the **Plugins** page in your workspace sidebar:
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_bsi-tr03183-v2.1-compliance.webm" title="Enabling the BSI TR-03183-2 plugin in sbomify" description="Step-by-step screencast showing how to enable the BSI TR-03183-2 v2.1.0 compliance plugin in sbomify." >}}
+
+## Related frameworks
+
+- [EU Cyber Resilience Act (CRA)](/compliance/eu-cra/) - the regulation BSI TR-03183-2 is designed to support
+- [Schema Crosswalk](/compliance/schema-crosswalk/) - field mappings across CycloneDX 1.7, SPDX 2.3, and SPDX 3.0
+- [NTIA Minimum Elements (2021)](/compliance/ntia-minimum-elements/) - the US baseline; BSI's component fields go further
+
+## Additional resources
+
+- [BSI TR-03183 official page (English)](https://bsi.bund.de/dok/TR-03183-en)
+- [BSI CycloneDX Property Taxonomy](https://github.com/BSI-Bund/tr-03183-cyclonedx-property-taxonomy) - the property names BSI uses to express its extra fields in CycloneDX
+
+---
+
+**Disclaimer:** This page represents our interpretation of the referenced framework. While we strive for accuracy, we may have made errors or omissions. This content is provided for informational purposes only and does not constitute legal advice. For compliance decisions, consult the official source documents and seek qualified legal counsel.
+
+[← Back to Compliance Overview](/compliance/)

--- a/content/compliance/eu-cra.md
+++ b/content/compliance/eu-cra.md
@@ -68,7 +68,7 @@ The CRA empowers the European Commission to "specify the format and elements of 
 
 ## BSI TR-03183-2: Concrete SBOM Requirements
 
-[BSI TR-03183-2](https://bsi.bund.de/dok/TR-03183-en) (v2.1.0, August 2025) from Germany's Federal Office for Information Security provides detailed technical specifications for CRA-compliant SBOMs. Key requirements follow.
+[BSI TR-03183-2](https://bsi.bund.de/dok/TR-03183-en) (v2.1.0, August 2025) from Germany's Federal Office for Information Security provides detailed technical specifications for CRA-compliant SBOMs. Key requirements follow. For the standalone summary, see our [BSI TR-03183-2 page](/compliance/bsi-tr-03183/).
 
 > **Note on interpretations:** BSI TR-03183-2 represents the **first published technical interpretation** of CRA SBOM requirements by an EU member state authority. Other EU countries may publish their own interpretations, which could differ in specific requirements. As additional national interpretations emerge, we will update this page to reflect the evolving compliance landscape.
 

--- a/content/compliance/fda-medical-device.md
+++ b/content/compliance/fda-medical-device.md
@@ -51,6 +51,12 @@ For technical guidance on representing support level and end-of-support date in 
 - [NTIA Minimum Elements](/compliance/ntia-minimum-elements/) - Baseline attributes referenced by FDA
 - [CISA Framing Document](/compliance/cisa-framing/) - Source of baseline attribute definitions
 
+## Score uploaded SBOMs against the FDA checklist
+
+sbomify ships an **FDA Medical Device (2025)** plugin that grades each uploaded SBOM against the FDA baseline attributes plus the support-level and end-of-support lifecycle properties. Enable it from the **Plugins** page in your workspace sidebar:
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_fda-medical-device-2025.webm" title="Enabling the FDA Medical Device plugin in sbomify" description="Step-by-step screencast showing how to enable the FDA Medical Device (2025) compliance plugin in sbomify." >}}
+
 ## Additional Resources
 
 For more details, see our [FDA Medical Device SBOM Requirements guide](/blog/fda-medical-device-sbom-requirements/).

--- a/content/faq/how-do-i-achieve-ntia-cisa-compliance.md
+++ b/content/faq/how-do-i-achieve-ntia-cisa-compliance.md
@@ -85,6 +85,12 @@ Then in your CI pipeline, simply enable augmentation with a sbomify account:
 
 sbomify-action will fetch the profile metadata from sbomify and apply it to the generated SBOM automatically.
 
+## Score uploaded SBOMs against the NTIA checklist
+
+sbomify ships a built-in **NTIA Minimum Elements (2021)** plugin that grades every uploaded SBOM against the seven required fields and surfaces the result on the SBOM detail page. Enable it from the **Plugins** page in your workspace sidebar:
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_ntia-minimum-elements-2021.webm" title="Enabling the NTIA Minimum Elements plugin in sbomify" description="Step-by-step screencast showing how to enable the NTIA Minimum Elements (2021) compliance plugin in sbomify." >}}
+
 ## What gets added
 
 Augmentation addresses specific NTIA and CISA minimum element fields:

--- a/content/faq/how-do-i-achieve-ntia-cisa-compliance.md
+++ b/content/faq/how-do-i-achieve-ntia-cisa-compliance.md
@@ -56,19 +56,19 @@ This is ideal for individual projects or teams that want to manage metadata per-
 
 ## Option 2: Central profile management in sbomify
 
-For organizations managing many components, sbomify provides centrally managed augmentation profiles. Instead of maintaining `sbomify.json` files in every repository, you configure the metadata once in sbomify and it gets applied automatically during augmentation.
+For organizations managing many components, sbomify provides centrally managed **Contact Profiles**. Instead of maintaining `sbomify.json` files in every repository, you configure the supplier, author, and contact metadata once in sbomify and it gets applied automatically during augmentation.
 
 ### Creating a profile
 
-Navigate to your workspace settings to create an augmentation profile with your organization's supplier info, authors, licenses, and other metadata:
+In **Settings**, open the **Contacts** tab and click **Add Profile**. A profile contains one or more **Entities** (with manufacturer / supplier / author roles, name, email, phone, address, and website) and one or more **Contacts** on each entity (with author / security / technical roles). Toggle **Set as default** if this profile should apply to every component that does not override it.
 
-{{< video-embed-native video_url="https://marketing-assets.sbomify.com/profile_editing.webm" title="Creating an augmentation profile in sbomify" description="Walkthrough of creating a centrally managed augmentation profile in sbomify for NTIA/CISA compliance." >}}
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/profile_editing.webm" title="Creating a contact profile in sbomify" description="Walkthrough of creating a centrally managed contact profile in sbomify for NTIA/CISA compliance." >}}
 
 ### Using profiles
 
 Once you have a profile, there are two ways to apply it:
 
-- **Default profile** - Set a profile as the workspace default, and it will be used for all components in that workspace during augmentation
+- **Default profile** - Mark a profile as the workspace default, and it will be used for all components in that workspace during augmentation
 - **Per-component profile** - Manually select a specific profile on individual components for cases where different components need different metadata
 
 Then in your CI pipeline, simply enable augmentation with a sbomify account:

--- a/content/faq/how-do-i-create-a-software-release.md
+++ b/content/faq/how-do-i-create-a-software-release.md
@@ -14,7 +14,7 @@ url: /faq/how-do-i-create-a-software-release/
 
 ## Creating a product release
 
-A product release in sbomify ties together one or more component SBOMs under a single version tag. This is how you represent a shipped version of your software.
+A product release in sbomify ties together one or more component SBOMs (and other artifacts like compliance documents) under a single version. This is how you represent a shipped version of your software.
 
 ### Prerequisites
 
@@ -23,13 +23,18 @@ Before creating a release, you need:
 - A **product** set up in sbomify (see [How do products work?](/faq/how-do-products-work-in-sbomify/))
 - One or more **components** with uploaded SBOMs
 
+### The "Latest" release
+
+The first time an SBOM is uploaded against a product, sbomify automatically creates a `Latest` release that always points to the most recent SBOM version of each component. You don't need to manage it - it's there as a stable URL for "whatever is current".
+
+Named releases (e.g. `v2.1.0`) are immutable snapshots and are what you should share with customers and auditors.
+
 ### Steps
 
-1. Navigate to your **Product**
-2. Click **Create Release**
-3. Enter the **release version** (e.g. `v2.1.0`)
-4. Select which **SBOMs** to include in this release
-5. Click **Save**
+1. Navigate to your **Product** and scroll to the **Releases** section
+2. Click **Create Release** and fill in the modal: **Name** (e.g. `Middle-Out Rewrite`), **Version** (e.g. `v2.1.0`), and an optional **Description**, then click **Create**
+3. Click into the new release
+4. Click **Add Artifact**, use **Select All Visible** (or pick individual SBOMs and documents) in the artifact picker, then click **Add to Release**
 
 ### How versioning works
 

--- a/content/faq/how-do-i-delete-a-workspace.md
+++ b/content/faq/how-do-i-delete-a-workspace.md
@@ -17,9 +17,8 @@ url: /faq/how-do-i-delete-a-workspace/
 To delete a workspace in sbomify:
 
 1. Navigate to your workspace **Settings**
-2. Go to the **General** tab
-3. Scroll down to the **Danger Zone** section
-4. Click **Delete Workspace**
-5. Confirm the deletion when prompted
+2. Stay on the **General** tab and scroll to the **Danger Zone** section
+3. Expand the Danger Zone and click **Delete Workspace**
+4. In the confirmation modal, type `delete` and click **Delete Workspace**
 
 This action is **permanent** and cannot be undone. All data associated with the workspace will be deleted, including products, projects, components, SBOMs, and documents.

--- a/content/faq/how-do-i-delete-my-account.md
+++ b/content/faq/how-do-i-delete-my-account.md
@@ -1,10 +1,10 @@
 ---
 title: "How do I delete my account?"
 description: "Step-by-step guide to deleting your account in sbomify, including what happens to your data."
-answer: "You can delete your account from Settings > Account > Delete Your Account. This permanently removes your account and all associated data."
-tldr: "You can delete your account from Settings > Account > Delete Your Account. This permanently removes your account and all associated data."
+answer: "Open Settings > Account, expand the Danger Zone, click Delete Account, type 'delete' to confirm, then click Delete My Account. This permanently removes your account and all associated data."
+tldr: "Open Settings > Account, expand the Danger Zone, click Delete Account, type 'delete' to confirm, then click Delete My Account. This permanently removes your account and all associated data."
 weight: 81
-keywords: [delete account, remove account, sbomify account, account settings, account deletion]
+keywords: [delete account, remove account, sbomify account, account settings, account deletion, danger zone]
 url: /faq/how-do-i-delete-my-account/
 ---
 
@@ -16,9 +16,9 @@ url: /faq/how-do-i-delete-my-account/
 
 To delete your account in sbomify:
 
-1. Navigate to **Settings**
-2. Go to the **Account** tab
-3. Click **Delete Your Account**
-4. Confirm the deletion when prompted
+1. Navigate to **Settings** and open the **Account** tab
+2. Scroll to the **Danger Zone** and expand it
+3. Click **Delete Account**
+4. In the confirmation modal, type `delete` and click **Delete My Account**
 
 This action is **permanent** and cannot be undone. All data associated with your account will be deleted.

--- a/content/faq/how-do-i-enable-tea-in-sbomify.md
+++ b/content/faq/how-do-i-enable-tea-in-sbomify.md
@@ -1,11 +1,11 @@
 ---
 title: "How do I enable the Transparency Exchange API (TEA) in sbomify?"
 description: "Step-by-step guide to enabling the Transparency Exchange API (TEA) in sbomify for automated SBOM discovery and distribution."
-answer: "You can enable TEA from your workspace settings. TEA requires a Business plan or higher."
-tldr: "You can enable TEA from your workspace settings. TEA requires a Business plan or higher."
+answer: "Enable your Trust Center under Settings > Trust Center, configure and validate a custom domain, then toggle on TEA. TEA requires a Business plan or higher."
+tldr: "Enable your Trust Center under Settings > Trust Center, configure and validate a custom domain, then toggle on TEA. TEA requires a Business plan or higher."
 plan: "Business+"
 weight: 72
-keywords: [TEA, Transparency Exchange API, SBOM distribution, SBOM discovery, sbomify TEA, enable TEA]
+keywords: [TEA, Transparency Exchange API, SBOM distribution, SBOM discovery, sbomify TEA, enable TEA, .well-known/tea]
 url: /faq/how-do-i-enable-tea-in-sbomify/
 ---
 
@@ -29,13 +29,14 @@ Instead of manually exchanging files via email or portals, TEA lets consumers pr
 
 ## Enabling TEA
 
-TEA is available on the **Business** plan and above.
+TEA is available on the **Business** plan and above. It is delivered through your Trust Center, so the Trust Center must be enabled and reachable on a validated custom domain before TEA can be turned on.
 
 To enable it:
 
-1. Navigate to your workspace **Settings**
-2. Go to the **TEA** section
-3. Toggle TEA on
-4. Configure your TEA endpoint settings
+1. Navigate to **Settings** and open the **Trust Center** tab
+2. **Enable** the Trust Center
+3. Set a **custom domain** (e.g. `trust.yourcompany.com`) and click **Save Domain**
+4. Configure the CNAME record at your DNS provider so the domain points to sbomify, then wait for validation
+5. Once the domain is validated, toggle **TEA** on
 
-Once enabled, your published SBOMs become discoverable via the TEA protocol, making it easy for customers and partners to access your transparency data automatically.
+After TEA is enabled, sbomify exposes a discovery URL at `https://<your-custom-domain>/.well-known/tea`. Consumers can hit that endpoint to programmatically discover and pull your published SBOMs and other transparency artifacts.

--- a/content/faq/how-do-i-enable-vulnerability-scanning.md
+++ b/content/faq/how-do-i-enable-vulnerability-scanning.md
@@ -8,16 +8,12 @@ keywords: [vulnerability scanning, OSV, Dependency Track, SBOM scanning, securit
 url: /faq/how-do-i-enable-vulnerability-scanning/
 ---
 
-## Walkthrough
-
-{{< video-embed-native video_url="https://marketing-assets.sbomify.com/vulnerability_scanning.webm" title="How to enable vulnerability scanning in sbomify" description="Step-by-step screencast showing how to enable and configure vulnerability scanning in sbomify." >}}
-
 ## How to enable
 
 Vulnerability scanning is implemented as a plugin. To enable it:
 
 1. Navigate to the **Plugins** page in your workspace sidebar
-2. Enable the **OSV** plugin (and/or **Dependency Track** if on a Business plan or above)
+2. Toggle the **OSV** plugin on (and/or **Dependency Track** if on a Business plan or above) and click **Save**
 
 Once enabled, any SBOM you upload is automatically scanned for known vulnerabilities. When you enable the plugin, recent SBOMs are also retroactively scanned.
 
@@ -34,9 +30,13 @@ sbomify periodically re-scans your SBOMs as vulnerability databases are updated.
 
 [Google OSV](https://osv.dev/) is available on every plan, including the free Community tier. It provides precise, distributed vulnerability intelligence across a wide range of ecosystems. Supports CycloneDX and SPDX 2.x formats.
 
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_osv.webm" title="Enabling the OSV plugin in sbomify" description="Step-by-step screencast showing how to enable the Google OSV vulnerability scanning plugin in sbomify." >}}
+
 ### Dependency Track (Business+)
 
 [OWASP Dependency Track](https://dependencytrack.org/) integration is available on Business plans and above for continuous component analysis. Dependency Track only supports CycloneDX format. Enterprise customers can connect their own Dependency Track instance for unified visibility across their existing security tooling.
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_dependency-track.webm" title="Enabling the Dependency Track plugin in sbomify" description="Step-by-step screencast showing how to enable the OWASP Dependency Track plugin in sbomify." >}}
 
 ## Further reading
 

--- a/content/faq/how-do-i-set-up-a-trust-center.md
+++ b/content/faq/how-do-i-set-up-a-trust-center.md
@@ -1,11 +1,11 @@
 ---
 title: "How do I set up a Trust Center in sbomify?"
-description: "Step-by-step guide to enabling and configuring a Trust Center in sbomify, including custom domain setup."
-answer: "Go to Settings > Trust Center, enable it, and set your custom domain. Trust Center requires a Business plan or higher."
-tldr: "Go to Settings > Trust Center, enable it, and set your custom domain. Trust Center requires a Business plan or higher."
+description: "Step-by-step guide to enabling and configuring a Trust Center in sbomify, including custom domain setup, security.txt, NDA upload, and component visibility."
+answer: "Go to Settings > Trust Center, enable it, optionally turn on security.txt and upload a Company NDA, then set your custom domain. Mark each component as Public, Gated, or Private to control what visitors can see. Trust Center requires a Business plan or higher."
+tldr: "Go to Settings > Trust Center, enable it, optionally turn on security.txt and upload a Company NDA, then set your custom domain. Mark each component as Public, Gated, or Private to control what visitors can see. Trust Center requires a Business plan or higher."
 plan: "Business+"
 weight: 71
-keywords: [Trust Center, set up Trust Center, enable Trust Center, custom domain, sbomify Trust Center, trust.sbomify.com]
+keywords: [Trust Center, set up Trust Center, enable Trust Center, custom domain, sbomify Trust Center, trust.sbomify.com, security.txt, RFC 9116, Company NDA, component visibility]
 url: /faq/how-do-i-set-up-a-trust-center/
 ---
 
@@ -19,21 +19,21 @@ The Trust Center is available on the **Business** plan and above. For background
 
 To set up your Trust Center:
 
-1. Navigate to **Settings**
-2. Go to the **Trust Center** section
-3. **Enable** your Trust Center
-4. Set your **custom domain** (e.g. `trust.yourcompany.com`)
-5. Configure a CNAME record with your DNS provider pointing to sbomify
+1. Navigate to **Settings** and open the **Trust Center** tab
+2. **Enable** your Trust Center
+3. (Optional) Toggle on **security.txt** to publish an [RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) `/.well-known/security.txt` file with your security contact details
+4. (Optional) Upload your **Company NDA** so it can be presented to visitors who request access to gated content
+5. Set your **custom domain** (e.g. `trust.yourcompany.com`) and click **Save Domain**
+6. Configure a CNAME record with your DNS provider pointing to sbomify, then wait for the domain to validate
 
 Once enabled, your uploaded SBOMs and compliance documents are automatically published to your Trust Center. You can see a live example at [trust.sbomify.com](https://trust.sbomify.com/).
 
-## Gated content
+## Component visibility
 
-Not everything needs to be public. sbomify lets you mark components as **gated**, meaning visitors must request access before they can view or download the artifacts. This is useful for sensitive documents like penetration test reports or detailed SBOMs that you only want to share under certain conditions.
+Not everything in a Trust Center needs to be public. Each component has a **visibility** setting on its detail page that controls how visitors interact with it:
 
-Gated content supports two modes:
+- **Public** - artifacts are listed and downloadable by anyone visiting the Trust Center
+- **Gated** - artifacts are listed but visitors must request access (and, if you uploaded one, accept your Company NDA) before they can download
+- **Private** - the component is hidden from the Trust Center entirely
 
-- **With NDA** -the visitor must accept your NDA before access is granted
-- **Without NDA** -the visitor requests access and you approve or deny it manually
-
-Either way, you stay in control of who sees what. Approval requests show up in your sbomify dashboard so you can review them.
+Gated content lets you keep control over sensitive artifacts like penetration test reports or detailed SBOMs. When the Company NDA is uploaded, gated requests must accept it; otherwise visitors simply request access and you approve or deny manually. Approval requests show up in your sbomify dashboard so you can review them.

--- a/content/faq/how-do-i-sign-an-sbom.md
+++ b/content/faq/how-do-i-sign-an-sbom.md
@@ -87,6 +87,14 @@ The combination means the signature is tied to a verified identity (your GitHub 
 
 sbomify can verify attestations automatically when you upload signed SBOMs. The [GitHub Attestation Plugin](/2026/01/23/announcing-sbomify-v0-25-the-one-with-attestations/) uses Sigstore and cosign to check signatures on upload, giving you a verified provenance status for every SBOM in your portfolio.
 
+Enable it from the **Plugins** page in your workspace sidebar:
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_github-attestation.webm" title="Enabling the GitHub Attestation plugin in sbomify" description="Step-by-step screencast showing how to enable the GitHub Attestation verification plugin in sbomify." >}}
+
+For a broader integrity check that re-computes the SBOM digest, validates any attached cosign signature, and confirms the provenance subject digest matches the SBOM hash, enable the **SBOM Verification** plugin alongside it:
+
+{{< video-embed-native video_url="https://marketing-assets.sbomify.com/plugin_enablement_sbom-verification.webm" title="Enabling the SBOM Verification plugin in sbomify" description="Step-by-step screencast showing how to enable the SBOM Verification plugin in sbomify for digest, signature, and provenance checks." >}}
+
 This closes the loop: your CI pipeline signs the SBOM, sbomify verifies the signature on ingestion, and your customers can independently verify the same signature when they download the SBOM from your Trust Center.
 
 ## Alternative: signing with your own certificates

--- a/content/faq/how-do-i-upload-compliance-documents.md
+++ b/content/faq/how-do-i-upload-compliance-documents.md
@@ -1,10 +1,10 @@
 ---
 title: "How do I upload compliance documents?"
-description: "Step-by-step guide to uploading compliance documents like SOC 2, ISO 27001, and CE certificates in sbomify."
-answer: "You can upload compliance documents (SOC 2, ISO 27001, CE certificates, etc.) to any project in sbomify by navigating to the project and using the Documents section."
-tldr: "You can upload compliance documents (SOC 2, ISO 27001, CE certificates, etc.) to any project in sbomify by navigating to the project and using the Documents section."
+description: "Step-by-step guide to uploading compliance documents like SOC 2, ISO 27001, and CE certificates in sbomify by creating a Document component."
+answer: "Compliance documents live on Document-type components. From Components, create a workspace-wide Document component (e.g. SOC 2 Type II Compliance), then upload the file with its version, document type, subcategory, and description."
+tldr: "Compliance documents live on Document-type components. From Components, create a workspace-wide Document component (e.g. SOC 2 Type II Compliance), then upload the file with its version, document type, subcategory, and description."
 weight: 76
-keywords: [compliance documents, SOC 2, ISO 27001, CE certificate, upload documents, sbomify documents]
+keywords: [compliance documents, SOC 2, ISO 27001, CE certificate, upload documents, sbomify documents, Document component, workspace-wide component]
 url: /faq/how-do-i-upload-compliance-documents/
 ---
 
@@ -14,14 +14,13 @@ url: /faq/how-do-i-upload-compliance-documents/
 
 ## Uploading compliance documents
 
-sbomify lets you attach compliance documents -such as SOC 2 Type II reports, ISO 27001 certificates, CE certificates, and other attestations -directly to your projects. This keeps your compliance artifacts alongside your SBOMs in one place.
+sbomify treats compliance documents - such as SOC 2 Type II reports, ISO 27001 certificates, CE certificates, and other attestations - as **Document components**. Like SBOM components they hold versioned artifacts, but their content is a PDF instead of an SBOM. Marking the component as **workspace-wide** means a single SOC 2 report can be linked into every project and product that needs it, without re-uploading.
 
 To upload a compliance document:
 
-1. Navigate to your **Project**
-2. Go to the **Documents** section
-3. Click **Upload Document**
-4. Select the file and fill in the document details
-5. Click **Save**
+1. Navigate to **Components** in the workspace sidebar
+2. Click **Add Component**, name it (e.g. `SOC 2 Type II Compliance`), set **Type** to **Document**, and tick **Workspace-wide component**, then submit
+3. Open the new component and fill in the upload form: **Version** (e.g. `2024`), **Document Type** (e.g. `Compliance`), **Subcategory** (e.g. `SOC 2`), and a short **Description**
+4. Choose the file and click **Save Document**
 
-Uploaded documents are visible to anyone with access to the project and can be shared via your [Trust Center](/faq/what-is-a-trust-center/).
+The uploaded document appears in the component's documents table and can be linked to any project or product that uses this component, and shared externally via your [Trust Center](/faq/what-is-a-trust-center/).


### PR DESCRIPTION
## Summary

The screencasts under `sbomify/screencasts/` have moved on, but the matching FAQ walkthroughs hadn't caught up. This refreshes them so the steps on the page match what viewers actually see in the recordings.

- **Trust Center setup** - now covers the `security.txt` (RFC 9116) toggle, Company NDA upload, "Save Domain" step, and per-component Public/Gated/Private visibility (replaces the older "gated content" framing)
- **TEA enablement** - corrected: TEA lives under Settings → Trust Center, requires the Trust Center enabled and a validated custom domain, and exposes a discovery URL at `/.well-known/tea` on that domain
- **Compliance documents** - rewrote: documents are uploaded by creating a workspace-wide **Document component** (not on a project), with Version / Type / Subcategory / Description fields and a "Save Document" button
- **Software release** - documents the auto-created **Latest** release, the modal's Name + Version + Description fields, and the **Add Artifact → Select All Visible → Add to Release** flow
- **NTIA/CISA compliance** - "augmentation profile" is now **Contact Profile** (Settings → Contacts), with Entities (manufacturer/supplier/author roles) and Contacts on each entity
- **Account & workspace deletion** - call out the Danger Zone expand step and the type-`delete`-to-confirm modal

## Test plan

- [ ] `hugo --minify --environment production` builds without errors
- [ ] Spot-check each updated FAQ page renders correctly and the embedded screencast still loads
- [ ] Verify the steps in each FAQ match the corresponding screencast recording

🤖 Generated with [Claude Code](https://claude.com/claude-code)