### PR TITLE
Redesign author page as a unified editorial hero

### DIFF
--- a/layouts/authors/list.html
+++ b/layouts/authors/list.html
@@ -26,7 +26,7 @@
                 </picture>
               {{ end }}
             </div>
-            <div class="text-left flex-grow">
+            <div class="text-center md:text-left flex-grow">
               <h2 class="text-2xl font-bold text-primaryText !mt-0 !mb-2">{{ $author.display_name }}</h2>
               <p class="text-secondaryText leading-relaxed mb-0 text-lg">{{ $author.bio | truncate 200 }}</p>
             </div>
@@ -67,115 +67,21 @@
 </script>
 
 <div>
-  <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+  {{ partial "author-bio-card.html" $author }}
 
-    <div class="relative max-w-4xl mx-auto text-center">
-      <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
-        <span class="text-gradient">{{ $author.display_name }}</span>
-      </h1>
-    </div>
-  </div>
-
+  {{ $authorPosts := where (where site.RegularPages "Section" "posts") ".Params.author.display_name" $author.display_name }}
+  {{ if gt (len $authorPosts) 0 }}
   <div class="bg-[#F6F9FA]">
-    <div class="max-w-4xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
-      <!-- Author Bio Section -->
-      <article class="bg-white p-8 md:p-12 rounded-2xl shadow-sm border border-gray-100 mb-16">
-        <div class="flex flex-col md:flex-row gap-8 md:gap-12">
-          <!-- Author Photo -->
-          <div class="flex-shrink-0 flex justify-center md:block">
-            {{ $imgPath := strings.TrimPrefix "/assets/" $author.image }}
-            {{ $img := resources.Get $imgPath }}
-            {{ if $img }}
-              {{ $webp := $img.Process "fit 448x448 webp q80" }}
-              <picture>
-                <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
-                <img src="{{ $img.RelPermalink }}" alt="{{ $author.display_name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
-              </picture>
-            {{ else }}
-              <img src="{{ $author.image }}" alt="{{ $author.display_name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
-            {{ end }}
-          </div>
-
-          <!-- Author Info -->
-          <div class="flex-grow">
-            <div class="flex flex-wrap items-center gap-3 mb-6">
-              {{ with $author.linkedin }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-[#0077b5] hover:text-[#006097] transition-colors" title="LinkedIn">
-                {{ partial "icon.html" (dict "name" "linkedin" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.twitter }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-800 hover:text-gray-600 transition-colors" title="X (Twitter)">
-                {{ partial "icon.html" (dict "name" "x-twitter" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.mastodon }}
-              <a href="{{ . }}" target="_blank" rel="me noopener noreferrer" class="inline-flex items-center text-[#6364FF] hover:text-[#563ACC] transition-colors" title="Mastodon">
-                {{ partial "icon.html" (dict "name" "mastodon" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.github }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-800 hover:text-gray-600 transition-colors" title="GitHub">
-                {{ partial "icon.html" (dict "name" "github" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.website }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-600 hover:text-[#8A7DFF] transition-colors" title="Website">
-                {{ partial "icon.html" (dict "name" "globe" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.podcast }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-600 hover:text-[#8A7DFF] transition-colors" title="Podcast">
-                {{ partial "icon.html" (dict "name" "podcast" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-            </div>
-
-            <p class="text-gray-600 leading-relaxed text-lg">
-              {{ $author.bio }}
-            </p>
-          </div>
-        </div>
-      </article>
-
-      <!-- Posts by Author Section -->
-      {{ $authorPosts := where (where site.RegularPages "Section" "posts") ".Params.author.display_name" $author.display_name }}
-      {{ if gt (len $authorPosts) 0 }}
-      {{ $paginator := .Paginate $authorPosts }}
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-3xl lg:text-4xl font-bold text-primaryText mb-12 text-center">Posts by {{ $author.display_name }}</h2>
-
-        <div class="flex flex-col gap-6">
-          {{ range $paginator.Pages }}
-          <a href="{{ .RelPermalink }}" class="bg-white p-6 md:p-8 rounded-2xl shadow-sm border border-gray-100 transition-all duration-300 hover:border-[#8A7DFF] hover:shadow-md block no-underline">
-            <h3 class="text-xl font-bold text-primaryText mb-2 !mt-0">{{ .Title }}</h3>
-            <div class="flex flex-wrap items-center gap-3 text-sm text-gray-500 mb-3">
-              <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-                {{ .Date.Format "January 2, 2006" }}
-              </time>
-              {{ with .GetTerms "categories" }}{{ range . }}
-              <span>&bull;</span>
-              <a href="{{ .RelPermalink }}" class="capitalize text-gray-600 hover:text-[#8A7DFF] transition-colors">{{ .LinkTitle }}</a>
-              {{ end }}{{ end }}
-            </div>
-            {{ with .Params.description }}
-            <p class="text-gray-600 mb-0">{{ . | truncate 150 }}</p>
-            {{ end }}
-          </a>
-          {{ end }}
-        </div>
-
-        {{ if gt $paginator.TotalPages 1 }}
-        <div class="mt-12">
-          {{ partial "pagination.html" . }}
-        </div>
-        {{ end }}
-      </div>
-      {{ end }}
+    <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+      {{ partial "posts.html" (dict
+        "context" .
+        "pages" $authorPosts
+        "paginate" true
+        "title" (printf "Posts by %s" $author.display_name)
+      ) }}
     </div>
   </div>
+  {{ end }}
 </div>
 {{ end }}{{/* end if author_key */}}
 {{ end }}

--- a/layouts/authors/single.html
+++ b/layouts/authors/single.html
@@ -29,107 +29,19 @@
 </script>
 
 <div>
-  <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+  {{ partial "author-bio-card.html" $author }}
 
-    <div class="relative max-w-4xl mx-auto text-center">
-      <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
-        <span class="text-gradient">{{ $author.display_name }}</span>
-      </h1>
-    </div>
-  </div>
-
+  {{ $authorPosts := where (where site.RegularPages "Section" "posts") ".Params.author.display_name" $author.display_name }}
+  {{ if gt (len $authorPosts) 0 }}
   <div class="bg-[#F6F9FA]">
-    <div class="max-w-4xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
-      <!-- Author Bio Section -->
-      <article class="bg-white p-8 md:p-12 rounded-2xl shadow-sm border border-gray-100 mb-16">
-        <div class="flex flex-col md:flex-row gap-8 md:gap-12">
-          <!-- Author Photo -->
-          <div class="flex-shrink-0 flex justify-center md:block">
-            {{ $imgPath := strings.TrimPrefix "/assets/" $author.image }}
-            {{ $img := resources.Get $imgPath }}
-            {{ if $img }}
-              {{ $webp := $img.Process "fit 448x448 webp q80" }}
-              <picture>
-                <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
-                <img src="{{ $img.RelPermalink }}" alt="{{ $author.display_name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
-              </picture>
-            {{ else }}
-              <img src="{{ $author.image }}" alt="{{ $author.display_name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
-            {{ end }}
-          </div>
-
-          <!-- Author Info -->
-          <div class="flex-grow">
-            <div class="flex flex-wrap items-center gap-3 mb-6">
-              {{ with $author.linkedin }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-[#0077b5] hover:text-[#006097] transition-colors" title="LinkedIn">
-                {{ partial "icon.html" (dict "name" "linkedin" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.twitter }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-800 hover:text-gray-600 transition-colors" title="X (Twitter)">
-                {{ partial "icon.html" (dict "name" "x-twitter" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.mastodon }}
-              <a href="{{ . }}" target="_blank" rel="me noopener noreferrer" class="inline-flex items-center text-[#6364FF] hover:text-[#563ACC] transition-colors" title="Mastodon">
-                {{ partial "icon.html" (dict "name" "mastodon" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.github }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-800 hover:text-gray-600 transition-colors" title="GitHub">
-                {{ partial "icon.html" (dict "name" "github" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.website }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-600 hover:text-[#8A7DFF] transition-colors" title="Website">
-                {{ partial "icon.html" (dict "name" "globe" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-              {{ with $author.podcast }}
-              <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center text-gray-600 hover:text-[#8A7DFF] transition-colors" title="Podcast">
-                {{ partial "icon.html" (dict "name" "podcast" "class" "w-6 h-6") }}
-              </a>
-              {{ end }}
-            </div>
-
-            <p class="text-gray-600 leading-relaxed text-lg">
-              {{ $author.bio }}
-            </p>
-          </div>
-        </div>
-      </article>
-
-      <!-- Posts by Author Section -->
-      {{ $authorPosts := where (where site.RegularPages "Section" "posts") ".Params.author.display_name" $author.display_name }}
-      {{ if gt (len $authorPosts) 0 }}
-      <div class="max-w-4xl mx-auto">
-        <h2 class="text-3xl lg:text-4xl font-bold text-primaryText mb-12 text-center">Posts by {{ $author.display_name }}</h2>
-
-        <div class="flex flex-col gap-6">
-          {{ range $authorPosts }}
-          <a href="{{ .RelPermalink }}" class="bg-white p-6 md:p-8 rounded-2xl shadow-sm border border-gray-100 transition-all duration-300 hover:border-[#8A7DFF] hover:shadow-md block no-underline">
-            <h3 class="text-xl font-bold text-primaryText mb-2 !mt-0">{{ .Title }}</h3>
-            <div class="flex flex-wrap items-center gap-3 text-sm text-gray-500 mb-3">
-              <time datetime="{{ .Date.Format "2006-01-02T15:04:05Z07:00" }}">
-                {{ .Date.Format "January 2, 2006" }}
-              </time>
-              {{ with .GetTerms "categories" }}{{ range . }}
-              <span>&bull;</span>
-              <a href="{{ .RelPermalink }}" class="capitalize text-gray-600 hover:text-[#8A7DFF] transition-colors">{{ .LinkTitle }}</a>
-              {{ end }}{{ end }}
-            </div>
-            {{ with .Params.description }}
-            <p class="text-gray-600 mb-0">{{ . | truncate 150 }}</p>
-            {{ end }}
-          </a>
-          {{ end }}
-        </div>
-      </div>
-      {{ end }}
+    <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
+      {{ partial "posts.html" (dict
+        "context" .
+        "pages" $authorPosts
+        "title" (printf "Posts by %s" $author.display_name)
+      ) }}
     </div>
   </div>
+  {{ end }}
 </div>
 {{ end }}

--- a/layouts/partials/author-bio-card.html
+++ b/layouts/partials/author-bio-card.html
@@ -1,0 +1,76 @@
+{{- $author := . -}}
+{{- $hasSocial := or $author.linkedin $author.twitter $author.mastodon $author.github $author.website $author.podcast -}}
+
+<div class="bg-primaryBG relative overflow-hidden">
+  <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/10 via-transparent to-transparent pointer-events-none"></div>
+  <div class="hidden lg:block absolute top-1/2 left-[12%] -translate-y-1/2 w-[460px] h-[460px] bg-[#8A7DFF]/20 rounded-full blur-[140px] pointer-events-none"></div>
+
+  <div class="relative max-w-7xl mx-auto px-6 py-16 lg:py-24">
+    <div class="flex flex-col lg:flex-row items-center gap-10 lg:gap-16">
+
+      <div class="flex-shrink-0">
+        {{ $imgPath := strings.TrimPrefix "/assets/" $author.image }}
+        {{ $img := resources.Get $imgPath }}
+        {{ if $img }}
+          {{ $webp := $img.Process "fit 448x448 webp q85" }}
+          <picture>
+            <source srcset="{{ $webp.RelPermalink }}" type="image/webp">
+            <img src="{{ $img.RelPermalink }}" alt="{{ $author.display_name }}" class="w-40 h-40 lg:w-56 lg:h-56 object-cover rounded-full ring-2 ring-[#8A7DFF]/40 shadow-[0_0_80px_-20px_rgba(138,125,255,0.6)] !m-0" width="224" height="224" loading="eager" fetchpriority="high">
+          </picture>
+        {{ else if $author.image }}
+          <img src="{{ $author.image }}" alt="{{ $author.display_name }}" class="w-40 h-40 lg:w-56 lg:h-56 object-cover rounded-full ring-2 ring-[#8A7DFF]/40 shadow-[0_0_80px_-20px_rgba(138,125,255,0.6)] !m-0" width="224" height="224" loading="eager" fetchpriority="high">
+        {{ end }}
+      </div>
+
+      <div class="flex-1 min-w-0 text-center lg:text-left">
+        <div class="max-w-2xl mx-auto lg:mx-0">
+        <p class="text-fuschia60 text-xs tracking-[0.25em] uppercase font-medium mb-4">Author</p>
+
+        <h1 class="text-white text-[40px] lg:text-[64px] leading-[44px] lg:leading-[68px] mb-6">
+          <span class="text-gradient">{{ $author.display_name }}</span>
+        </h1>
+
+        <p class="text-gray-300 text-base lg:text-lg leading-relaxed mb-8">
+          {{ $author.bio }}
+        </p>
+
+        {{ if $hasSocial }}
+        <div class="flex flex-wrap items-center justify-center lg:justify-start gap-3">
+          {{ with $author.linkedin }}
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }} on LinkedIn" aria-label="{{ $author.display_name }} on LinkedIn">
+            {{ partial "icon.html" (dict "name" "linkedin" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+          {{ with $author.twitter }}
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }} on X" aria-label="{{ $author.display_name }} on X">
+            {{ partial "icon.html" (dict "name" "x-twitter" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+          {{ with $author.mastodon }}
+          <a href="{{ . }}" target="_blank" rel="me noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }} on Mastodon" aria-label="{{ $author.display_name }} on Mastodon">
+            {{ partial "icon.html" (dict "name" "mastodon" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+          {{ with $author.github }}
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }} on GitHub" aria-label="{{ $author.display_name }} on GitHub">
+            {{ partial "icon.html" (dict "name" "github" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+          {{ with $author.website }}
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }}'s website" aria-label="{{ $author.display_name }}'s website">
+            {{ partial "icon.html" (dict "name" "globe" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+          {{ with $author.podcast }}
+          <a href="{{ . }}" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center w-10 h-10 rounded-full bg-white/5 backdrop-blur-sm border border-white/10 text-gray-300 hover:text-white hover:bg-white/10 hover:border-[#8A7DFF]/60 transition-all duration-200" title="{{ $author.display_name }}'s podcast" aria-label="{{ $author.display_name }}'s podcast">
+            {{ partial "icon.html" (dict "name" "podcast" "class" "w-4 h-4") }}
+          </a>
+          {{ end }}
+        </div>
+        {{ end }}
+        </div>
+      </div>
+
+    </div>
+  </div>
+</div>


### PR DESCRIPTION
## Summary

- Collapses the redundant gradient-text hero + plain white bio card on author pages into a single dark-themed header. The author's name now appears once instead of twice.
- Promotes the photo to a large circular focal element with a subtle purple ring and soft glow against the existing `bg-primaryBG` gradient.
- Replaces the bespoke single-column post list with the shared `posts.html` / `post-card.html` partials, so the grid, hover, and footer metadata match `/blog/` and the category/tag pages.
- Extracts the header into `layouts/partials/author-bio-card.html` so `list.html` and `single.html` stay in sync.

Net diff: +98 / −204 (3 files).

Affects all author pages — `/authors/vpetersson/`, `/authors/cswan/`, and any future authors.

## Test plan

- [ ] Visit `/authors/vpetersson/` and confirm hero + posts grid render correctly
- [ ] Visit `/authors/cswan/` and confirm hero + posts grid render correctly
- [ ] Confirm `/authors/` index page still lists authors as cards
- [ ] Resize from mobile → desktop and verify the hero stacks (photo above, content below) on small screens and lays out side-by-side at `lg`
- [ ] Confirm photo's left edge aligns with the navigation pill above it
- [ ] Confirm social icons render (LinkedIn / Twitter / Mastodon / GitHub / website / podcast as applicable per author)
- [ ] Confirm clicking a post card on an author page navigates to the post

🤖 Generated with [Claude Code](https://claude.com/claude-code)