### PR TITLE
polish: modernization sweep — aurora hero, eyebrow chips, refined components

### DIFF
--- a/_assets/css/tailwind.css
+++ b/_assets/css/tailwind.css
@@ -20,9 +20,25 @@
 @tailwind base;
 
 @layer base {
+  html {
+    scroll-behavior: smooth;
+    /* Offset anchors so they clear the sticky pill header */
+    scroll-padding-top: 6rem;
+  }
+
   body {
     color: #141035;
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    /* Inter Variable stylistic alternates: better i/l/g, single-storey a, etc. */
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
+  }
+
+  ::selection {
+    background-color: rgba(138, 125, 255, 0.28);
+    color: inherit;
   }
 
   :focus-visible {
@@ -42,12 +58,14 @@
   h1, h2, h3, h4, h5, h6 {
     color: #141035;
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
+    text-wrap: balance;
   }
 
   h1 {
     font-size: 4.25rem; /* 68px */
     font-weight: 500;
     line-height: 4.875rem; /* 78px */
+    letter-spacing: -0.025em;
   }
 
   h2 {
@@ -55,6 +73,7 @@
     font-style: normal;
     font-weight: 400;
     line-height: 120%;
+    letter-spacing: -0.018em;
   }
 
   @media (min-width: 768px) {
@@ -63,12 +82,17 @@
     }
   }
 
+  h3 {
+    letter-spacing: -0.012em;
+  }
+
   p {
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
     font-size: 0.875rem; /* 14px */
     font-style: normal;
     font-weight: 400;
     line-height: 1.5;
+    text-wrap: pretty;
   }
 
   @media (min-width: 768px) {
@@ -217,6 +241,79 @@
     -webkit-text-fill-color: transparent;
   }
 
+  /* Hero aurora — animated radial gradients drifting behind the hero text. */
+  .aurora {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(80px);
+    will-change: transform;
+    pointer-events: none;
+  }
+  .aurora-1 {
+    width: 32rem;
+    height: 32rem;
+    top: 2rem;
+    left: -4rem;
+    background: radial-gradient(circle at center, rgba(138, 125, 255, 0.55), rgba(138, 125, 255, 0) 70%);
+    animation: aurora-drift-1 20s ease-in-out infinite alternate;
+  }
+  .aurora-2 {
+    width: 38rem;
+    height: 38rem;
+    bottom: -8rem;
+    right: -6rem;
+    background: radial-gradient(circle at center, rgba(204, 88, 187, 0.4), rgba(204, 88, 187, 0) 70%);
+    animation: aurora-drift-2 26s ease-in-out infinite alternate;
+  }
+  .aurora-3 {
+    width: 28rem;
+    height: 28rem;
+    top: 30%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: radial-gradient(circle at center, rgba(64, 89, 208, 0.3), rgba(64, 89, 208, 0) 70%);
+    animation: aurora-drift-3 24s ease-in-out infinite alternate;
+  }
+  @keyframes aurora-drift-1 {
+    0%   { transform: translate3d(0, 0, 0) scale(1); }
+    100% { transform: translate3d(8rem, 5rem, 0) scale(1.15); }
+  }
+  @keyframes aurora-drift-2 {
+    0%   { transform: translate3d(0, 0, 0) scale(1.1); }
+    100% { transform: translate3d(-6rem, -8rem, 0) scale(1); }
+  }
+  @keyframes aurora-drift-3 {
+    0%   { transform: translate3d(-50%, 0, 0) scale(1); }
+    100% { transform: translate3d(-50%, 4rem, 0) scale(1.2); }
+  }
+  @media (prefers-reduced-motion: reduce) {
+    .aurora-1, .aurora-2, .aurora-3 { animation: none; }
+  }
+
+  /* Eyebrow chip — refined section-label component. */
+  .eyebrow-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.875rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #8A7DFF;
+    background: rgba(138, 125, 255, 0.08);
+    border: 1px solid rgba(138, 125, 255, 0.2);
+  }
+  .eyebrow-chip::before {
+    content: "";
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: 9999px;
+    background: #8A7DFF;
+    box-shadow: 0 0 0 3px rgba(138, 125, 255, 0.18);
+  }
+
   .divider {
     border: 0;
     height: 1px;
@@ -332,6 +429,7 @@
   font-size: 1.125rem; /* 18px */
   line-height: 1.7;
   margin-bottom: 1.5rem; /* 24px */
+  text-wrap: pretty;
 }
 
 @media (min-width: 768px) {

--- a/_assets/css/tailwind.css
+++ b/_assets/css/tailwind.css
@@ -41,6 +41,13 @@
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
   }
 
+  /* Firefox legacy alias — autoprefixer also emits this from ::selection,
+     but we declare both explicitly so source ↔ compiled CSS stay 1:1. */
+  ::-moz-selection {
+    background-color: rgba(138, 125, 255, 0.28);
+    color: inherit;
+  }
+
   ::selection {
     background-color: rgba(138, 125, 255, 0.28);
     color: inherit;

--- a/_assets/css/tailwind.css
+++ b/_assets/css/tailwind.css
@@ -21,9 +21,14 @@
 
 @layer base {
   html {
-    scroll-behavior: smooth;
     /* Offset anchors so they clear the sticky pill header */
     scroll-padding-top: 6rem;
+  }
+
+  @media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
   }
 
   body {
@@ -241,12 +246,13 @@
     -webkit-text-fill-color: transparent;
   }
 
-  /* Hero aurora — animated radial gradients drifting behind the hero text. */
+  /* Hero aurora — animated radial gradients drifting behind the hero text.
+     Animation + GPU-promotion are gated behind prefers-reduced-motion: no-preference,
+     so reduced-motion users get static orbs without an idle compositor layer. */
   .aurora {
     position: absolute;
     border-radius: 9999px;
     filter: blur(80px);
-    will-change: transform;
     pointer-events: none;
   }
   .aurora-1 {
@@ -255,7 +261,6 @@
     top: 2rem;
     left: -4rem;
     background: radial-gradient(circle at center, rgba(138, 125, 255, 0.55), rgba(138, 125, 255, 0) 70%);
-    animation: aurora-drift-1 20s ease-in-out infinite alternate;
   }
   .aurora-2 {
     width: 38rem;
@@ -263,7 +268,6 @@
     bottom: -8rem;
     right: -6rem;
     background: radial-gradient(circle at center, rgba(204, 88, 187, 0.4), rgba(204, 88, 187, 0) 70%);
-    animation: aurora-drift-2 26s ease-in-out infinite alternate;
   }
   .aurora-3 {
     width: 28rem;
@@ -272,7 +276,14 @@
     left: 50%;
     transform: translateX(-50%);
     background: radial-gradient(circle at center, rgba(64, 89, 208, 0.3), rgba(64, 89, 208, 0) 70%);
-    animation: aurora-drift-3 24s ease-in-out infinite alternate;
+  }
+  @media (prefers-reduced-motion: no-preference) {
+    .aurora {
+      will-change: transform;
+    }
+    .aurora-1 { animation: aurora-drift-1 20s ease-in-out infinite alternate; }
+    .aurora-2 { animation: aurora-drift-2 26s ease-in-out infinite alternate; }
+    .aurora-3 { animation: aurora-drift-3 24s ease-in-out infinite alternate; }
   }
   @keyframes aurora-drift-1 {
     0%   { transform: translate3d(0, 0, 0) scale(1); }
@@ -285,9 +296,6 @@
   @keyframes aurora-drift-3 {
     0%   { transform: translate3d(-50%, 0, 0) scale(1); }
     100% { transform: translate3d(-50%, 4rem, 0) scale(1.2); }
-  }
-  @media (prefers-reduced-motion: reduce) {
-    .aurora-1, .aurora-2, .aurora-3 { animation: none; }
   }
 
   /* Eyebrow chip — refined section-label component. */

--- a/_assets/css/tailwind.css
+++ b/_assets/css/tailwind.css
@@ -285,6 +285,18 @@
     .aurora-2 { animation: aurora-drift-2 26s ease-in-out infinite alternate; }
     .aurora-3 { animation: aurora-drift-3 24s ease-in-out infinite alternate; }
   }
+
+  /* Globally respect prefers-reduced-motion for Tailwind's built-in keyframe
+     utilities. Tailwind doesn't auto-gate these, and our motion-safe: prefix
+     isn't picked up by purge inside JS string literals. */
+  @media (prefers-reduced-motion: reduce) {
+    .animate-ping,
+    .animate-pulse,
+    .animate-spin,
+    .animate-bounce {
+      animation: none;
+    }
+  }
   @keyframes aurora-drift-1 {
     0%   { transform: translate3d(0, 0, 0) scale(1); }
     100% { transform: translate3d(8rem, 5rem, 0) scale(1.15); }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -545,6 +545,9 @@ body {
     font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
   }
 
+/* Firefox legacy alias — autoprefixer also emits this from ::selection,
+     but we declare both explicitly so source ↔ compiled CSS stay 1:1. */
+
 ::-moz-selection {
     background-color: rgba(138, 125, 255, 0.28);
     color: inherit;
@@ -633,54 +636,35 @@ button:hover {
     opacity: 0.8;
   }
 
-.\!container {
-  width: 100% !important;
-}
-
 .container {
   width: 100%;
 }
 
 @media (min-width: 640px) {
-  .\!container {
-    max-width: 640px !important;
-  }
   .container {
     max-width: 640px;
   }
 }
 
 @media (min-width: 768px) {
-  .\!container {
-    max-width: 768px !important;
-  }
   .container {
     max-width: 768px;
   }
 }
 
 @media (min-width: 1024px) {
-  .\!container {
-    max-width: 1024px !important;
-  }
   .container {
     max-width: 1024px;
   }
 }
 
 @media (min-width: 1280px) {
-  .\!container {
-    max-width: 1280px !important;
-  }
   .container {
     max-width: 1280px;
   }
 }
 
 @media (min-width: 1536px) {
-  .\!container {
-    max-width: 1536px !important;
-  }
   .container {
     max-width: 1536px;
   }

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1552,10 +1552,6 @@ a.button:hover {
   border-color: rgb(138 125 255 / 0.2);
 }
 
-.border-\[\#8A7DFF\]\/30 {
-  border-color: rgb(138 125 255 / 0.3);
-}
-
 .border-blue-500 {
   --tw-border-opacity: 1;
   border-color: rgb(59 130 246 / var(--tw-border-opacity, 1));
@@ -1598,6 +1594,14 @@ a.button:hover {
 .border-purple-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 232 255 / var(--tw-border-opacity, 1));
+}
+
+.border-purple\/20 {
+  border-color: rgb(138 125 255 / 0.2);
+}
+
+.border-purple\/30 {
+  border-color: rgb(138 125 255 / 0.3);
 }
 
 .border-white {
@@ -1734,6 +1738,14 @@ a.button:hover {
   background-color: rgb(250 245 255 / var(--tw-bg-opacity, 1));
 }
 
+.bg-purple\/10 {
+  background-color: rgb(138 125 255 / 0.1);
+}
+
+.bg-purple\/20 {
+  background-color: rgb(138 125 255 / 0.2);
+}
+
 .bg-red-50 {
   --tw-bg-opacity: 1;
   background-color: rgb(254 242 242 / var(--tw-bg-opacity, 1));
@@ -1774,12 +1786,6 @@ a.button:hover {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
-.from-\[\#6C5CE7\] {
-  --tw-gradient-from: #6C5CE7 var(--tw-gradient-from-position);
-  --tw-gradient-to: rgb(108 92 231 / 0) var(--tw-gradient-to-position);
-  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
-}
-
 .from-\[\#8A7DFF\]\/10 {
   --tw-gradient-from: rgb(138 125 255 / 0.1) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(138 125 255 / 0) var(--tw-gradient-to-position);
@@ -1801,6 +1807,12 @@ a.button:hover {
 .from-primaryBG\/0 {
   --tw-gradient-from: rgb(20 16 53 / 0) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(20 16 53 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-purple-700 {
+  --tw-gradient-from: #7A6DE5 var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(122 109 229 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
@@ -1835,16 +1847,16 @@ a.button:hover {
   --tw-gradient-to: #151236 var(--tw-gradient-to-position);
 }
 
-.to-\[\#8A7DFF\] {
-  --tw-gradient-to: #8A7DFF var(--tw-gradient-to-position);
-}
-
 .to-gray-50 {
   --tw-gradient-to: #f9fafb var(--tw-gradient-to-position);
 }
 
 .to-primaryBG\/40 {
   --tw-gradient-to: rgb(20 16 53 / 0.4) var(--tw-gradient-to-position);
+}
+
+.to-purple {
+  --tw-gradient-to: #8A7DFF var(--tw-gradient-to-position);
 }
 
 .to-transparent {
@@ -2506,14 +2518,32 @@ a.button:hover {
   transition-duration: 150ms;
 }
 
+.transition-\[border-color\2c box-shadow\] {
+  transition-property: border-color,box-shadow;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .transition-\[border-color\2c transform\] {
   transition-property: border-color,transform;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
 
+.transition-\[box-shadow\2c border-color\] {
+  transition-property: box-shadow,border-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
 .transition-\[box-shadow\2c transform\2c border-color\] {
   transition-property: box-shadow,transform,border-color;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-\[filter\] {
+  transition-property: filter;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -3319,10 +3349,6 @@ a.button:hover {
   background-color: rgb(138 125 255 / 0.2);
 }
 
-.hover\:bg-\[\#8A7DFF\]\/30:hover {
-  background-color: rgb(138 125 255 / 0.3);
-}
-
 .hover\:bg-gray-800:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(31 41 55 / var(--tw-bg-opacity, 1));
@@ -3331,6 +3357,14 @@ a.button:hover {
 .hover\:bg-purple-700:hover {
   --tw-bg-opacity: 1;
   background-color: rgb(122 109 229 / var(--tw-bg-opacity, 1));
+}
+
+.hover\:bg-purple\/20:hover {
+  background-color: rgb(138 125 255 / 0.2);
+}
+
+.hover\:bg-purple\/30:hover {
+  background-color: rgb(138 125 255 / 0.3);
 }
 
 .hover\:bg-white\/10:hover {
@@ -3349,11 +3383,6 @@ a.button:hover {
 .hover\:text-\[\#006097\]:hover {
   --tw-text-opacity: 1;
   color: rgb(0 96 151 / var(--tw-text-opacity, 1));
-}
-
-.hover\:text-\[\#7A6DE5\]:hover {
-  --tw-text-opacity: 1;
-  color: rgb(122 109 229 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-\[\#8A7DFF\]:hover {
@@ -3460,7 +3489,7 @@ a.button:hover {
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
-.focus\:border-\[\#8A7DFF\]:focus {
+.focus\:border-purple:focus {
   --tw-border-opacity: 1;
   border-color: rgb(138 125 255 / var(--tw-border-opacity, 1));
 }
@@ -3476,7 +3505,7 @@ a.button:hover {
   box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
 }
 
-.focus\:ring-\[\#8A7DFF\]\/20:focus {
+.focus\:ring-purple\/20:focus {
   --tw-ring-color: rgb(138 125 255 / 0.2);
 }
 
@@ -3491,14 +3520,19 @@ a.button:hover {
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
-.group:hover .group-hover\:text-\[\#7A6DE5\] {
-  --tw-text-opacity: 1;
-  color: rgb(122 109 229 / var(--tw-text-opacity, 1));
-}
-
 .group:hover .group-hover\:text-\[\#8A7DFF\] {
   --tw-text-opacity: 1;
   color: rgb(138 125 255 / var(--tw-text-opacity, 1));
+}
+
+.group:hover .group-hover\:text-purple {
+  --tw-text-opacity: 1;
+  color: rgb(138 125 255 / var(--tw-text-opacity, 1));
+}
+
+.group:hover .group-hover\:text-purple-700 {
+  --tw-text-opacity: 1;
+  color: rgb(122 109 229 / var(--tw-text-opacity, 1));
 }
 
 .group:hover .group-hover\:text-white {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -633,35 +633,54 @@ button:hover {
     opacity: 0.8;
   }
 
+.\!container {
+  width: 100% !important;
+}
+
 .container {
   width: 100%;
 }
 
 @media (min-width: 640px) {
+  .\!container {
+    max-width: 640px !important;
+  }
   .container {
     max-width: 640px;
   }
 }
 
 @media (min-width: 768px) {
+  .\!container {
+    max-width: 768px !important;
+  }
   .container {
     max-width: 768px;
   }
 }
 
 @media (min-width: 1024px) {
+  .\!container {
+    max-width: 1024px !important;
+  }
   .container {
     max-width: 1024px;
   }
 }
 
 @media (min-width: 1280px) {
+  .\!container {
+    max-width: 1280px !important;
+  }
   .container {
     max-width: 1280px;
   }
 }
 
 @media (min-width: 1536px) {
+  .\!container {
+    max-width: 1536px !important;
+  }
   .container {
     max-width: 1536px;
   }
@@ -2634,6 +2653,19 @@ a.button:hover {
     .aurora-1 { animation: aurora-drift-1 20s ease-in-out infinite alternate; }
     .aurora-2 { animation: aurora-drift-2 26s ease-in-out infinite alternate; }
     .aurora-3 { animation: aurora-drift-3 24s ease-in-out infinite alternate; }
+  }
+
+/* Globally respect prefers-reduced-motion for Tailwind's built-in keyframe
+     utilities. Tailwind doesn't auto-gate these, and our motion-safe: prefix
+     isn't picked up by purge inside JS string literals. */
+
+@media (prefers-reduced-motion: reduce) {
+    .animate-ping,
+    .animate-pulse,
+    .animate-spin,
+    .animate-bounce {
+      animation: none;
+    }
   }
 
 @keyframes aurora-drift-1 {

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -524,9 +524,30 @@ video {
   display: none;
 }
 
+html {
+    scroll-behavior: smooth;
+    /* Offset anchors so they clear the sticky pill header */
+    scroll-padding-top: 6rem;
+  }
+
 body {
     color: #141035;
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
+    -webkit-font-smoothing: antialiased;
+    -moz-osx-font-smoothing: grayscale;
+    text-rendering: optimizeLegibility;
+    /* Inter Variable stylistic alternates: better i/l/g, single-storey a, etc. */
+    font-feature-settings: "cv02", "cv03", "cv04", "cv11", "ss01";
+  }
+
+::-moz-selection {
+    background-color: rgba(138, 125, 255, 0.28);
+    color: inherit;
+  }
+
+::selection {
+    background-color: rgba(138, 125, 255, 0.28);
+    color: inherit;
   }
 
 :focus-visible {
@@ -547,12 +568,14 @@ a:focus-visible,
 h1, h2, h3, h4, h5, h6 {
     color: #141035;
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
+    text-wrap: balance;
   }
 
 h1 {
     font-size: 4.25rem; /* 68px */
     font-weight: 500;
     line-height: 4.875rem; /* 78px */
+    letter-spacing: -0.025em;
   }
 
 h2 {
@@ -560,6 +583,7 @@ h2 {
     font-style: normal;
     font-weight: 400;
     line-height: 120%;
+    letter-spacing: -0.018em;
   }
 
 @media (min-width: 768px) {
@@ -568,12 +592,17 @@ h2 {
     }
   }
 
+h3 {
+    letter-spacing: -0.012em;
+  }
+
 p {
     font-family: "Inter Variable", "Inter", ui-sans-serif, system-ui, sans-serif;
     font-size: 0.875rem; /* 14px */
     font-style: normal;
     font-weight: 400;
     line-height: 1.5;
+    text-wrap: pretty;
   }
 
 @media (min-width: 768px) {
@@ -762,6 +791,11 @@ a.button:hover {
   inset: 0px;
 }
 
+.inset-x-0 {
+  left: 0px;
+  right: 0px;
+}
+
 .-right-20 {
   right: -5rem;
 }
@@ -778,12 +812,20 @@ a.button:hover {
   left: 0px;
 }
 
+.left-\[12\%\] {
+  left: 12%;
+}
+
 .right-0 {
   right: 0px;
 }
 
 .top-0 {
   top: 0px;
+}
+
+.top-1\/2 {
+  top: 50%;
 }
 
 .z-10 {
@@ -885,6 +927,10 @@ a.button:hover {
 
 .mb-4 {
   margin-bottom: 1rem;
+}
+
+.mb-5 {
+  margin-bottom: 1.25rem;
 }
 
 .mb-6 {
@@ -1010,6 +1056,10 @@ a.button:hover {
   display: none;
 }
 
+.h-10 {
+  height: 2.5rem;
+}
+
 .h-12 {
   height: 3rem;
 }
@@ -1032,6 +1082,10 @@ a.button:hover {
 
 .h-4 {
   height: 1rem;
+}
+
+.h-40 {
+  height: 10rem;
 }
 
 .h-48 {
@@ -1066,6 +1120,10 @@ a.button:hover {
   height: 30px;
 }
 
+.h-\[460px\] {
+  height: 460px;
+}
+
 .h-\[500px\] {
   height: 500px;
 }
@@ -1078,8 +1136,16 @@ a.button:hover {
   height: 100%;
 }
 
+.h-px {
+  height: 1px;
+}
+
 .max-h-12 {
   max-height: 3rem;
+}
+
+.w-10 {
+  width: 2.5rem;
 }
 
 .w-12 {
@@ -1100,6 +1166,10 @@ a.button:hover {
 
 .w-4 {
   width: 1rem;
+}
+
+.w-40 {
+  width: 10rem;
 }
 
 .w-48 {
@@ -1126,6 +1196,10 @@ a.button:hover {
   width: 2rem;
 }
 
+.w-\[460px\] {
+  width: 460px;
+}
+
 .w-\[500px\] {
   width: 500px;
 }
@@ -1136,6 +1210,10 @@ a.button:hover {
 
 .w-full {
   width: 100%;
+}
+
+.min-w-0 {
+  min-width: 0px;
 }
 
 .max-w-2xl {
@@ -1196,6 +1274,11 @@ a.button:hover {
 
 .-translate-x-1\/3 {
   --tw-translate-x: -33.333333%;
+  transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+}
+
+.-translate-y-1\/2 {
+  --tw-translate-y: -50%;
   transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
 }
 
@@ -1382,6 +1465,14 @@ a.button:hover {
   white-space: nowrap;
 }
 
+.text-pretty {
+  text-wrap: pretty;
+}
+
+.\!rounded-none {
+  border-radius: 0px !important;
+}
+
 .rounded {
   border-radius: 0.25rem;
 }
@@ -1475,6 +1566,10 @@ a.button:hover {
   border-color: rgb(229 231 235 / var(--tw-border-opacity, 1));
 }
 
+.border-gray-200\/70 {
+  border-color: rgb(229 231 235 / 0.7);
+}
+
 .border-gray-50 {
   --tw-border-opacity: 1;
   border-color: rgb(249 250 251 / var(--tw-border-opacity, 1));
@@ -1490,6 +1585,11 @@ a.button:hover {
   border-color: rgb(220 252 231 / var(--tw-border-opacity, 1));
 }
 
+.border-primary-600 {
+  --tw-border-opacity: 1;
+  border-color: rgb(55 48 107 / var(--tw-border-opacity, 1));
+}
+
 .border-purple-100 {
   --tw-border-opacity: 1;
   border-color: rgb(243 232 255 / var(--tw-border-opacity, 1));
@@ -1502,6 +1602,10 @@ a.button:hover {
 
 .border-white\/10 {
   border-color: rgb(255 255 255 / 0.1);
+}
+
+.border-white\/15 {
+  border-color: rgb(255 255 255 / 0.15);
 }
 
 .bg-\[\#141035\] {
@@ -1600,9 +1704,19 @@ a.button:hover {
   background-color: rgb(253 242 248 / var(--tw-bg-opacity, 1));
 }
 
+.bg-primary-light {
+  --tw-bg-opacity: 1;
+  background-color: rgb(32 27 76 / var(--tw-bg-opacity, 1));
+}
+
 .bg-primaryBG {
   --tw-bg-opacity: 1;
   background-color: rgb(20 16 53 / var(--tw-bg-opacity, 1));
+}
+
+.bg-purple {
+  --tw-bg-opacity: 1;
+  background-color: rgb(138 125 255 / var(--tw-bg-opacity, 1));
 }
 
 .bg-purple-100 {
@@ -1661,8 +1775,8 @@ a.button:hover {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
-.from-\[\#8A7DFF\]\/5 {
-  --tw-gradient-from: rgb(138 125 255 / 0.05) var(--tw-gradient-from-position);
+.from-\[\#8A7DFF\]\/10 {
+  --tw-gradient-from: rgb(138 125 255 / 0.1) var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(138 125 255 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
@@ -1679,10 +1793,32 @@ a.button:hover {
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
 }
 
+.from-primaryBG\/0 {
+  --tw-gradient-from: rgb(20 16 53 / 0) var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(20 16 53 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.from-transparent {
+  --tw-gradient-from: transparent var(--tw-gradient-from-position);
+  --tw-gradient-to: rgb(0 0 0 / 0) var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
 .from-white {
   --tw-gradient-from: #FFFFFF var(--tw-gradient-from-position);
   --tw-gradient-to: rgb(255 255 255 / 0) var(--tw-gradient-to-position);
   --tw-gradient-stops: var(--tw-gradient-from), var(--tw-gradient-to);
+}
+
+.via-primary-600 {
+  --tw-gradient-to: rgb(55 48 107 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), #37306B var(--tw-gradient-via-position), var(--tw-gradient-to);
+}
+
+.via-primaryBG\/0 {
+  --tw-gradient-to: rgb(20 16 53 / 0)  var(--tw-gradient-to-position);
+  --tw-gradient-stops: var(--tw-gradient-from), rgb(20 16 53 / 0) var(--tw-gradient-via-position), var(--tw-gradient-to);
 }
 
 .via-transparent {
@@ -1700,6 +1836,10 @@ a.button:hover {
 
 .to-gray-50 {
   --tw-gradient-to: #f9fafb var(--tw-gradient-to-position);
+}
+
+.to-primaryBG\/40 {
+  --tw-gradient-to: rgb(20 16 53 / 0.4) var(--tw-gradient-to-position);
 }
 
 .to-transparent {
@@ -1976,8 +2116,16 @@ a.button:hover {
   font-style: italic;
 }
 
+.leading-\[1\.05\] {
+  line-height: 1.05;
+}
+
 .leading-\[27px\] {
   line-height: 27px;
+}
+
+.leading-\[44px\] {
+  line-height: 44px;
 }
 
 .leading-\[48px\] {
@@ -1992,8 +2140,16 @@ a.button:hover {
   line-height: 1.25;
 }
 
+.tracking-\[0\.25em\] {
+  letter-spacing: 0.25em;
+}
+
 .tracking-\[1\.8px\] {
   letter-spacing: 1.8px;
+}
+
+.tracking-tight {
+  letter-spacing: -0.025em;
 }
 
 .tracking-wide {
@@ -2037,11 +2193,6 @@ a.button:hover {
 .text-\[\#201B4C\] {
   --tw-text-opacity: 1;
   color: rgb(32 27 76 / var(--tw-text-opacity, 1));
-}
-
-.text-\[\#6364FF\] {
-  --tw-text-opacity: 1;
-  color: rgb(99 100 255 / var(--tw-text-opacity, 1));
 }
 
 .text-\[\#6C5CE7\] {
@@ -2124,9 +2275,19 @@ a.button:hover {
   color: rgb(22 163 74 / var(--tw-text-opacity, 1));
 }
 
+.text-primary-light {
+  --tw-text-opacity: 1;
+  color: rgb(32 27 76 / var(--tw-text-opacity, 1));
+}
+
 .text-primaryText {
   --tw-text-opacity: 1;
   color: rgb(20 16 53 / var(--tw-text-opacity, 1));
+}
+
+.text-purple {
+  --tw-text-opacity: 1;
+  color: rgb(138 125 255 / var(--tw-text-opacity, 1));
 }
 
 .text-red-500 {
@@ -2153,6 +2314,10 @@ a.button:hover {
   color: rgb(255 255 255 / var(--tw-text-opacity, 1));
 }
 
+.text-white\/90 {
+  color: rgb(255 255 255 / 0.9);
+}
+
 .text-yellow-400 {
   --tw-text-opacity: 1;
   color: rgb(250 204 21 / var(--tw-text-opacity, 1));
@@ -2170,8 +2335,16 @@ a.button:hover {
   text-decoration-line: none;
 }
 
+.decoration-purple\/40 {
+  text-decoration-color: rgb(138 125 255 / 0.4);
+}
+
 .underline-offset-2 {
   text-underline-offset: 2px;
+}
+
+.underline-offset-4 {
+  text-underline-offset: 4px;
 }
 
 .placeholder-gray-400::-moz-placeholder {
@@ -2204,9 +2377,27 @@ a.button:hover {
   opacity: 0.75;
 }
 
+.\!shadow-none {
+  --tw-shadow: 0 0 #0000 !important;
+  --tw-shadow-colored: 0 0 #0000 !important;
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow) !important;
+}
+
 .shadow-2xl {
   --tw-shadow: 0 25px 50px -12px rgb(0 0 0 / 0.25);
   --tw-shadow-colored: 0 25px 50px -12px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_0_80px_-20px_rgba\(138\2c 125\2c 255\2c 0\.6\)\] {
+  --tw-shadow: 0 0 80px -20px rgba(138,125,255,0.6);
+  --tw-shadow-colored: 0 0 80px -20px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-\[0_1px_3px_rgba\(20\2c 16\2c 53\2c 0\.04\)\2c 0_8px_24px_-12px_rgba\(20\2c 16\2c 53\2c 0\.08\)\] {
+  --tw-shadow: 0 1px 3px rgba(20,16,53,0.04),0 8px 24px -12px rgba(20,16,53,0.08);
+  --tw-shadow-colored: 0 1px 3px var(--tw-shadow-color), 0 8px 24px -12px var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
@@ -2216,10 +2407,46 @@ a.button:hover {
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
+.shadow-md {
+  --tw-shadow: 0 4px 6px -1px rgb(0 0 0 / 0.1), 0 2px 4px -2px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 4px 6px -1px var(--tw-shadow-color), 0 2px 4px -2px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
 .shadow-sm {
   --tw-shadow: 0 1px 2px 0 rgb(0 0 0 / 0.05);
   --tw-shadow-colored: 0 1px 2px 0 var(--tw-shadow-color);
   box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.shadow-purple\/20 {
+  --tw-shadow-color: rgb(138 125 255 / 0.2);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.shadow-purple\/25 {
+  --tw-shadow-color: rgb(138 125 255 / 0.25);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.ring-1 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(1px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-2 {
+  --tw-ring-offset-shadow: var(--tw-ring-inset) 0 0 0 var(--tw-ring-offset-width) var(--tw-ring-offset-color);
+  --tw-ring-shadow: var(--tw-ring-inset) 0 0 0 calc(2px + var(--tw-ring-offset-width)) var(--tw-ring-color);
+  box-shadow: var(--tw-ring-offset-shadow), var(--tw-ring-shadow), var(--tw-shadow, 0 0 #0000);
+}
+
+.ring-\[\#8A7DFF\]\/40 {
+  --tw-ring-color: rgb(138 125 255 / 0.4);
+}
+
+.ring-black\/\[0\.02\] {
+  --tw-ring-color: rgb(0 0 0 / 0.02);
 }
 
 .blur-3xl {
@@ -2229,6 +2456,11 @@ a.button:hover {
 
 .blur-\[120px\] {
   --tw-blur: blur(120px);
+  filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
+}
+
+.blur-\[140px\] {
+  --tw-blur: blur(140px);
   filter: var(--tw-blur) var(--tw-brightness) var(--tw-contrast) var(--tw-grayscale) var(--tw-hue-rotate) var(--tw-invert) var(--tw-saturate) var(--tw-sepia) var(--tw-drop-shadow);
 }
 
@@ -2246,8 +2478,37 @@ a.button:hover {
   backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
 }
 
+.backdrop-blur-sm {
+  --tw-backdrop-blur: blur(4px);
+  backdrop-filter: var(--tw-backdrop-blur) var(--tw-backdrop-brightness) var(--tw-backdrop-contrast) var(--tw-backdrop-grayscale) var(--tw-backdrop-hue-rotate) var(--tw-backdrop-invert) var(--tw-backdrop-opacity) var(--tw-backdrop-saturate) var(--tw-backdrop-sepia);
+}
+
 .transition {
   transition-property: color, background-color, border-color, text-decoration-color, fill, stroke, opacity, box-shadow, transform, filter, backdrop-filter;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-\[background-color\2c border-color\2c transform\] {
+  transition-property: background-color,border-color,transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-\[background-color\2c box-shadow\2c transform\] {
+  transition-property: background-color,box-shadow,transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-\[border-color\2c transform\] {
+  transition-property: border-color,transform;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+.transition-\[box-shadow\2c transform\2c border-color\] {
+  transition-property: box-shadow,transform,border-color;
   transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
   transition-duration: 150ms;
 }
@@ -2293,6 +2554,89 @@ a.button:hover {
     background-clip: text;
     -webkit-background-clip: text;
     -webkit-text-fill-color: transparent;
+  }
+
+/* Hero aurora — animated radial gradients drifting behind the hero text. */
+
+.aurora {
+    position: absolute;
+    border-radius: 9999px;
+    filter: blur(80px);
+    will-change: transform;
+    pointer-events: none;
+  }
+
+.aurora-1 {
+    width: 32rem;
+    height: 32rem;
+    top: 2rem;
+    left: -4rem;
+    background: radial-gradient(circle at center, rgba(138, 125, 255, 0.55), rgba(138, 125, 255, 0) 70%);
+    animation: aurora-drift-1 20s ease-in-out infinite alternate;
+  }
+
+.aurora-2 {
+    width: 38rem;
+    height: 38rem;
+    bottom: -8rem;
+    right: -6rem;
+    background: radial-gradient(circle at center, rgba(204, 88, 187, 0.4), rgba(204, 88, 187, 0) 70%);
+    animation: aurora-drift-2 26s ease-in-out infinite alternate;
+  }
+
+.aurora-3 {
+    width: 28rem;
+    height: 28rem;
+    top: 30%;
+    left: 50%;
+    transform: translateX(-50%);
+    background: radial-gradient(circle at center, rgba(64, 89, 208, 0.3), rgba(64, 89, 208, 0) 70%);
+    animation: aurora-drift-3 24s ease-in-out infinite alternate;
+  }
+
+@keyframes aurora-drift-1 {
+    0%   { transform: translate3d(0, 0, 0) scale(1); }
+    100% { transform: translate3d(8rem, 5rem, 0) scale(1.15); }
+  }
+
+@keyframes aurora-drift-2 {
+    0%   { transform: translate3d(0, 0, 0) scale(1.1); }
+    100% { transform: translate3d(-6rem, -8rem, 0) scale(1); }
+  }
+
+@keyframes aurora-drift-3 {
+    0%   { transform: translate3d(-50%, 0, 0) scale(1); }
+    100% { transform: translate3d(-50%, 4rem, 0) scale(1.2); }
+  }
+
+@media (prefers-reduced-motion: reduce) {
+    .aurora-1, .aurora-2, .aurora-3 { animation: none; }
+  }
+
+/* Eyebrow chip — refined section-label component. */
+
+.eyebrow-chip {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.5rem;
+    padding: 0.375rem 0.875rem;
+    border-radius: 9999px;
+    font-size: 0.75rem;
+    font-weight: 600;
+    letter-spacing: 0.08em;
+    text-transform: uppercase;
+    color: #8A7DFF;
+    background: rgba(138, 125, 255, 0.08);
+    border: 1px solid rgba(138, 125, 255, 0.2);
+  }
+
+.eyebrow-chip::before {
+    content: "";
+    width: 0.375rem;
+    height: 0.375rem;
+    border-radius: 9999px;
+    background: #8A7DFF;
+    box-shadow: 0 0 0 3px rgba(138, 125, 255, 0.18);
   }
 
 .max-container {
@@ -2403,6 +2747,7 @@ a.button:hover {
   font-size: 1.125rem; /* 18px */
   line-height: 1.7;
   margin-bottom: 1.5rem; /* 24px */
+  text-wrap: pretty;
 }
 
 @media (min-width: 768px) {
@@ -2940,9 +3285,21 @@ a.button:hover {
   border-color: rgb(138 125 255 / 0.3);
 }
 
-.hover\:bg-\[\#37306B\]:hover {
-  --tw-bg-opacity: 1;
-  background-color: rgb(55 48 107 / var(--tw-bg-opacity, 1));
+.hover\:border-\[\#8A7DFF\]\/60:hover {
+  border-color: rgb(138 125 255 / 0.6);
+}
+
+.hover\:border-purple:hover {
+  --tw-border-opacity: 1;
+  border-color: rgb(138 125 255 / var(--tw-border-opacity, 1));
+}
+
+.hover\:border-purple\/20:hover {
+  border-color: rgb(138 125 255 / 0.2);
+}
+
+.hover\:border-white\/25:hover {
+  border-color: rgb(255 255 255 / 0.25);
 }
 
 .hover\:bg-\[\#7A6DE5\]:hover {
@@ -2963,8 +3320,17 @@ a.button:hover {
   background-color: rgb(31 41 55 / var(--tw-bg-opacity, 1));
 }
 
+.hover\:bg-purple-700:hover {
+  --tw-bg-opacity: 1;
+  background-color: rgb(122 109 229 / var(--tw-bg-opacity, 1));
+}
+
 .hover\:bg-white\/10:hover {
   background-color: rgb(255 255 255 / 0.1);
+}
+
+.hover\:bg-white\/5:hover {
+  background-color: rgb(255 255 255 / 0.05);
 }
 
 .hover\:\!text-gray-900:hover {
@@ -2975,11 +3341,6 @@ a.button:hover {
 .hover\:text-\[\#006097\]:hover {
   --tw-text-opacity: 1;
   color: rgb(0 96 151 / var(--tw-text-opacity, 1));
-}
-
-.hover\:text-\[\#563ACC\]:hover {
-  --tw-text-opacity: 1;
-  color: rgb(86 58 204 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-\[\#7A6DE5\]:hover {
@@ -3002,9 +3363,14 @@ a.button:hover {
   color: rgb(30 58 138 / var(--tw-text-opacity, 1));
 }
 
-.hover\:text-gray-600:hover {
+.hover\:text-purple:hover {
   --tw-text-opacity: 1;
-  color: rgb(75 85 99 / var(--tw-text-opacity, 1));
+  color: rgb(138 125 255 / var(--tw-text-opacity, 1));
+}
+
+.hover\:text-purple-700:hover {
+  --tw-text-opacity: 1;
+  color: rgb(122 109 229 / var(--tw-text-opacity, 1));
 }
 
 .hover\:text-white:hover {
@@ -3014,6 +3380,10 @@ a.button:hover {
 
 .hover\:underline:hover {
   text-decoration-line: underline;
+}
+
+.hover\:decoration-purple-700:hover {
+  text-decoration-color: #7A6DE5;
 }
 
 .hover\:opacity-100:hover {
@@ -3026,6 +3396,18 @@ a.button:hover {
 
 .hover\:opacity-90:hover {
   opacity: 0.9;
+}
+
+.hover\:shadow-\[0_1px_3px_rgba\(20\2c 16\2c 53\2c 0\.04\)\2c 0_24px_48px_-16px_rgba\(138\2c 125\2c 255\2c 0\.18\)\]:hover {
+  --tw-shadow: 0 1px 3px rgba(20,16,53,0.04),0 24px 48px -16px rgba(138,125,255,0.18);
+  --tw-shadow-colored: 0 1px 3px var(--tw-shadow-color), 0 24px 48px -16px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
+}
+
+.hover\:shadow-lg:hover {
+  --tw-shadow: 0 10px 15px -3px rgb(0 0 0 / 0.1), 0 4px 6px -4px rgb(0 0 0 / 0.1);
+  --tw-shadow-colored: 0 10px 15px -3px var(--tw-shadow-color), 0 4px 6px -4px var(--tw-shadow-color);
+  box-shadow: var(--tw-ring-offset-shadow, 0 0 #0000), var(--tw-ring-shadow, 0 0 #0000), var(--tw-shadow);
 }
 
 .hover\:shadow-md:hover {
@@ -3042,6 +3424,26 @@ a.button:hover {
 
 .hover\:shadow-\[\#8A7DFF\]\/25:hover {
   --tw-shadow-color: rgb(138 125 255 / 0.25);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.hover\:shadow-purple\/10:hover {
+  --tw-shadow-color: rgb(138 125 255 / 0.1);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.hover\:shadow-purple\/20:hover {
+  --tw-shadow-color: rgb(138 125 255 / 0.2);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.hover\:shadow-purple\/30:hover {
+  --tw-shadow-color: rgb(138 125 255 / 0.3);
+  --tw-shadow: var(--tw-shadow-colored);
+}
+
+.hover\:shadow-purple\/40:hover {
+  --tw-shadow-color: rgb(138 125 255 / 0.4);
   --tw-shadow: var(--tw-shadow-colored);
 }
 
@@ -3098,6 +3500,26 @@ a.button:hover {
 
 .group:hover .group-hover\:opacity-100 {
   opacity: 1;
+}
+
+@media (prefers-reduced-motion: no-preference) {
+  .motion-safe\:hover\:-translate-y-0\.5:hover {
+    --tw-translate-y: -0.125rem;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+  .motion-safe\:hover\:-translate-y-1:hover {
+    --tw-translate-y: -0.25rem;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+  .group:hover .motion-safe\:group-hover\:translate-x-1 {
+    --tw-translate-x: 0.25rem;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
+  .group:hover .motion-safe\:group-hover\:scale-110 {
+    --tw-scale-x: 1.1;
+    --tw-scale-y: 1.1;
+    transform: translate(var(--tw-translate-x), var(--tw-translate-y)) rotate(var(--tw-rotate)) skewX(var(--tw-skew-x)) skewY(var(--tw-skew-y)) scaleX(var(--tw-scale-x)) scaleY(var(--tw-scale-y));
+  }
 }
 
 @media (min-width: 640px) {
@@ -3178,6 +3600,9 @@ a.button:hover {
     padding-top: 4rem;
     padding-bottom: 4rem;
   }
+  .md\:text-left {
+    text-align: left;
+  }
   .md\:text-3xl {
     font-size: 1.875rem;
     line-height: 2.25rem;
@@ -3185,6 +3610,10 @@ a.button:hover {
 }
 
 @media (min-width: 1024px) {
+  .lg\:mx-0 {
+    margin-left: 0px;
+    margin-right: 0px;
+  }
   .lg\:mb-20 {
     margin-bottom: 5rem;
   }
@@ -3197,6 +3626,12 @@ a.button:hover {
   .lg\:hidden {
     display: none;
   }
+  .lg\:h-56 {
+    height: 14rem;
+  }
+  .lg\:w-56 {
+    width: 14rem;
+  }
   .lg\:grid-cols-3 {
     grid-template-columns: repeat(3, minmax(0, 1fr));
   }
@@ -3208,6 +3643,9 @@ a.button:hover {
   }
   .lg\:items-end {
     align-items: flex-end;
+  }
+  .lg\:justify-start {
+    justify-content: flex-start;
   }
   .lg\:justify-end {
     justify-content: flex-end;
@@ -3257,10 +3695,6 @@ a.button:hover {
     font-size: 1.5rem;
     line-height: 2rem;
   }
-  .lg\:text-3xl {
-    font-size: 1.875rem;
-    line-height: 2.25rem;
-  }
   .lg\:text-4xl {
     font-size: 2.25rem;
     line-height: 2.5rem;
@@ -3273,12 +3707,22 @@ a.button:hover {
     font-size: 4.5rem;
     line-height: 1;
   }
+  .lg\:text-\[64px\] {
+    font-size: 64px;
+  }
   .lg\:text-\[68px\] {
     font-size: 68px;
+  }
+  .lg\:text-lg {
+    font-size: 1.125rem;
+    line-height: 1.75rem;
   }
   .lg\:text-xl {
     font-size: 1.25rem;
     line-height: 1.75rem;
+  }
+  .lg\:leading-\[68px\] {
+    line-height: 68px;
   }
   .lg\:leading-\[78px\] {
     line-height: 78px;

--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -525,9 +525,14 @@ video {
 }
 
 html {
-    scroll-behavior: smooth;
     /* Offset anchors so they clear the sticky pill header */
     scroll-padding-top: 6rem;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    html {
+      scroll-behavior: smooth;
+    }
   }
 
 body {
@@ -2556,13 +2561,14 @@ a.button:hover {
     -webkit-text-fill-color: transparent;
   }
 
-/* Hero aurora — animated radial gradients drifting behind the hero text. */
+/* Hero aurora — animated radial gradients drifting behind the hero text.
+     Animation + GPU-promotion are gated behind prefers-reduced-motion: no-preference,
+     so reduced-motion users get static orbs without an idle compositor layer. */
 
 .aurora {
     position: absolute;
     border-radius: 9999px;
     filter: blur(80px);
-    will-change: transform;
     pointer-events: none;
   }
 
@@ -2572,7 +2578,6 @@ a.button:hover {
     top: 2rem;
     left: -4rem;
     background: radial-gradient(circle at center, rgba(138, 125, 255, 0.55), rgba(138, 125, 255, 0) 70%);
-    animation: aurora-drift-1 20s ease-in-out infinite alternate;
   }
 
 .aurora-2 {
@@ -2581,7 +2586,6 @@ a.button:hover {
     bottom: -8rem;
     right: -6rem;
     background: radial-gradient(circle at center, rgba(204, 88, 187, 0.4), rgba(204, 88, 187, 0) 70%);
-    animation: aurora-drift-2 26s ease-in-out infinite alternate;
   }
 
 .aurora-3 {
@@ -2591,7 +2595,15 @@ a.button:hover {
     left: 50%;
     transform: translateX(-50%);
     background: radial-gradient(circle at center, rgba(64, 89, 208, 0.3), rgba(64, 89, 208, 0) 70%);
-    animation: aurora-drift-3 24s ease-in-out infinite alternate;
+  }
+
+@media (prefers-reduced-motion: no-preference) {
+    .aurora {
+      will-change: transform;
+    }
+    .aurora-1 { animation: aurora-drift-1 20s ease-in-out infinite alternate; }
+    .aurora-2 { animation: aurora-drift-2 26s ease-in-out infinite alternate; }
+    .aurora-3 { animation: aurora-drift-3 24s ease-in-out infinite alternate; }
   }
 
 @keyframes aurora-drift-1 {
@@ -2607,10 +2619,6 @@ a.button:hover {
 @keyframes aurora-drift-3 {
     0%   { transform: translate3d(-50%, 0, 0) scale(1); }
     100% { transform: translate3d(-50%, 4rem, 0) scale(1.2); }
-  }
-
-@media (prefers-reduced-motion: reduce) {
-    .aurora-1, .aurora-2, .aurora-3 { animation: none; }
   }
 
 /* Eyebrow chip — refined section-label component. */

--- a/content/_index.html
+++ b/content/_index.html
@@ -195,31 +195,78 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
 </div>
 
 <script>
-  (window.requestIdleCallback || function(cb) { setTimeout(cb, 1) })(function() {
-    fetch('https://api.github.com/repos/sbomify/sbomify/releases/latest')
-      .then(function(r) { return r.json() })
-      .then(function(data) {
-        if (data.tag_name) {
-          var container = document.getElementById('gh-latest-version');
-          if (container) {
-            container.innerHTML = '<a href="' + data.html_url + '" target="_blank" class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple/10 border border-purple/20 hover:bg-purple/20 transition-colors group no-underline"><span class="relative flex h-2 w-2"><span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span><span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span></span><span class="text-xs font-medium text-purple group-hover:text-purple-700">Release ' + data.tag_name + '</span></a>';
-            container.classList.remove('hidden');
-          }
-        }
-      })
-      .catch(function() {});
+  (function() {
+    /* Build elements via createElement + textContent so values from the
+       GitHub API can never be parsed as HTML (no innerHTML on dynamic data). */
+    function makeEl(tag, className, attrs) {
+      var el = document.createElement(tag);
+      if (className) el.className = className;
+      if (attrs) for (var k in attrs) el.setAttribute(k, attrs[k]);
+      return el;
+    }
 
-    fetch('https://api.github.com/repos/sbomify/sbomify')
-      .then(function(r) { return r.json() })
-      .then(function(data) {
-        if (data.stargazers_count !== undefined) {
-          var container = document.getElementById('gh-star-cta');
-          if (container) {
-            container.innerHTML = '<a href="https://github.com/sbomify/sbomify" target="_blank" class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-gray-900 text-white hover:bg-gray-800 transition-colors no-underline group"><svg class="w-4 h-4 text-yellow-400" fill="currentColor" viewBox="0 0 20 20" aria-hidden="true"><path d="M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z"/></svg><span class="text-xs font-medium">Star us</span><span class="text-xs font-medium text-gray-400 border-l border-gray-700 pl-2 ml-1 group-hover:text-white transition-colors">' + data.stargazers_count.toLocaleString() + '</span></a>';
-            container.classList.remove('hidden');
-          }
-        }
-      })
-      .catch(function() {});
-  });
+    function renderRelease(data) {
+      var container = document.getElementById('gh-latest-version');
+      if (!container || !data || !data.tag_name) return;
+
+      var a = makeEl('a',
+        'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple/10 border border-purple/20 hover:bg-purple/20 transition-colors group no-underline',
+        { href: data.html_url, target: '_blank', rel: 'noopener noreferrer' });
+
+      var dot = makeEl('span', 'relative flex h-2 w-2', { 'aria-hidden': 'true' });
+      dot.appendChild(makeEl('span', 'motion-safe:animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75'));
+      dot.appendChild(makeEl('span', 'relative inline-flex rounded-full h-2 w-2 bg-green-500'));
+      a.appendChild(dot);
+
+      var label = makeEl('span', 'text-xs font-medium text-purple group-hover:text-purple-700');
+      label.textContent = 'Release ' + data.tag_name;
+      a.appendChild(label);
+
+      container.replaceChildren(a);
+      container.classList.remove('hidden');
+    }
+
+    function renderStars(data) {
+      var container = document.getElementById('gh-star-cta');
+      if (!container || !data || data.stargazers_count === undefined) return;
+
+      var a = makeEl('a',
+        'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-gray-900 text-white hover:bg-gray-800 transition-colors no-underline group',
+        { href: 'https://github.com/sbomify/sbomify', target: '_blank', rel: 'noopener noreferrer' });
+
+      var svgNS = 'http://www.w3.org/2000/svg';
+      var svg = document.createElementNS(svgNS, 'svg');
+      svg.setAttribute('class', 'w-4 h-4 text-yellow-400');
+      svg.setAttribute('fill', 'currentColor');
+      svg.setAttribute('viewBox', '0 0 20 20');
+      svg.setAttribute('aria-hidden', 'true');
+      var path = document.createElementNS(svgNS, 'path');
+      path.setAttribute('d', 'M9.049 2.927c.3-.921 1.603-.921 1.902 0l1.07 3.292a1 1 0 00.95.69h3.462c.969 0 1.371 1.24.588 1.81l-2.8 2.034a1 1 0 00-.364 1.118l1.07 3.292c.3.921-.755 1.688-1.54 1.118l-2.8-2.034a1 1 0 00-1.175 0l-2.8 2.034c-.784.57-1.838-.197-1.539-1.118l1.07-3.292a1 1 0 00-.364-1.118L2.98 8.72c-.783-.57-.38-1.81.588-1.81h3.461a1 1 0 00.951-.69l1.07-3.292z');
+      svg.appendChild(path);
+      a.appendChild(svg);
+
+      var label = makeEl('span', 'text-xs font-medium');
+      label.textContent = 'Star us';
+      a.appendChild(label);
+
+      var count = makeEl('span', 'text-xs font-medium text-gray-400 border-l border-gray-700 pl-2 ml-1 group-hover:text-white transition-colors');
+      count.textContent = data.stargazers_count.toLocaleString();
+      a.appendChild(count);
+
+      container.replaceChildren(a);
+      container.classList.remove('hidden');
+    }
+
+    (window.requestIdleCallback || function(cb) { setTimeout(cb, 1); })(function() {
+      fetch('https://api.github.com/repos/sbomify/sbomify/releases/latest')
+        .then(function(r) { return r.json(); })
+        .then(renderRelease)
+        .catch(function() {});
+
+      fetch('https://api.github.com/repos/sbomify/sbomify')
+        .then(function(r) { return r.json(); })
+        .then(renderStars)
+        .catch(function() {});
+    });
+  })();
 </script>

--- a/content/_index.html
+++ b/content/_index.html
@@ -208,16 +208,18 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
       return el;
     }
 
-    /* Allow only https links to a known sbomify GitHub host on hrefs derived
-       from the API response — defends against javascript: / data: URLs and
-       redirects to unrelated origins. */
+    /* Allow only https links to the exact sbomify/sbomify GitHub repo on
+       hrefs derived from the API response — defends against javascript: /
+       data: URLs and redirects to unrelated origins (including sibling repos
+       like /sbomify/sbomify-evil that would slip past a prefix check). */
     function safeGithubUrl(url) {
       if (typeof url !== 'string') return null;
       try {
         var parsed = new URL(url);
         if (parsed.protocol !== 'https:') return null;
         if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null;
-        if (parsed.pathname.indexOf('/sbomify/sbomify') !== 0) return null;
+        var p = parsed.pathname;
+        if (p !== '/sbomify/sbomify' && p.indexOf('/sbomify/sbomify/') !== 0) return null;
         return parsed.href;
       } catch (e) {
         return null;

--- a/content/_index.html
+++ b/content/_index.html
@@ -30,20 +30,20 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
             <!-- Integration Sections -->
             <div class="grid grid-cols-1 gap-6 max-w-4xl mx-auto">
                 <!-- Integrates With section -->
-                <div class="bg-[#201B4C] border border-[#37306B] rounded-2xl px-8 py-8 hover:border-[#8A7DFF] transition-all duration-300">
-                    <span class="text-[#8A7DFF] text-sm font-semibold uppercase tracking-wide mb-6 block text-center">Integrates With</span>
+                <div class="bg-primary-light border border-primary-600 rounded-2xl px-8 py-8 hover:border-purple transition-colors duration-300">
+                    <span class="text-purple text-sm font-semibold uppercase tracking-wide mb-6 block text-center">Integrates With</span>
                     <div class="flex flex-wrap items-center justify-center gap-6 md:gap-12 gap-y-6 md:gap-y-8">
-                        <a href="/features/integrations/#github" class="flex items-center gap-2 text-white font-semibold hover:text-[#8A7DFF] transition-colors">
-                            <span class="text-[#8A7DFF]">{{< icon "github" "w-6 h-6" >}}</span> GitHub
+                        <a href="/features/integrations/#github" class="flex items-center gap-2 text-white font-semibold hover:text-purple transition-colors">
+                            <span class="text-purple">{{< icon "github" "w-6 h-6" >}}</span> GitHub
                         </a>
-                        <a href="/features/integrations/#gitlab" class="flex items-center gap-2 text-white font-semibold hover:text-[#8A7DFF] transition-colors">
-                            <span class="text-[#8A7DFF]">{{< icon "gitlab" "w-6 h-6" >}}</span> GitLab
+                        <a href="/features/integrations/#gitlab" class="flex items-center gap-2 text-white font-semibold hover:text-purple transition-colors">
+                            <span class="text-purple">{{< icon "gitlab" "w-6 h-6" >}}</span> GitLab
                         </a>
-                        <a href="/features/integrations/#bitbucket" class="flex items-center gap-2 text-white font-semibold hover:text-[#8A7DFF] transition-colors">
-                            <span class="text-[#8A7DFF]">{{< icon "bitbucket" "w-6 h-6" >}}</span> Bitbucket
+                        <a href="/features/integrations/#bitbucket" class="flex items-center gap-2 text-white font-semibold hover:text-purple transition-colors">
+                            <span class="text-purple">{{< icon "bitbucket" "w-6 h-6" >}}</span> Bitbucket
                         </a>
-                        <a href="/features/integrations/#docker" class="flex items-center gap-2 text-white font-semibold hover:text-[#8A7DFF] transition-colors">
-                            <span class="text-[#8A7DFF]">{{< icon "docker" "w-6 h-6" >}}</span> Docker
+                        <a href="/features/integrations/#docker" class="flex items-center gap-2 text-white font-semibold hover:text-purple transition-colors">
+                            <span class="text-purple">{{< icon "docker" "w-6 h-6" >}}</span> Docker
                         </a>
                         <a href="/features/integrations/" class="hover:opacity-80 transition-opacity">
                             <img class="h-[30px] w-auto object-contain" src="/assets/images/site/osv.svg" alt="Google OSV" width="150" height="30" />
@@ -96,7 +96,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 <div class="eyebrow-chip mb-5">SBOM Lifecycle Tool</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Zero to SBOM Hero</h2>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
-                Build high-quality SBOMs directly in your CI pipeline with our <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">open source action</a>. Once generated, SBOMs are automatically uploaded to sbomify where you can manage releases (including <a href="/features/sbom-hierarchy/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">complex hierarchies</a>) and share the latest software versions with stakeholders – publicly or privately via your <a href="/features/trust-center/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Trust Center</a>. No more manual SBOM distribution or version confusion.
+                Build high-quality SBOMs directly in your CI pipeline with our <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">open source action</a>. Once generated, SBOMs are automatically uploaded to sbomify where you can manage releases (including <a href="/features/sbom-hierarchy/" class="text-purple hover:text-purple-700 underline">complex hierarchies</a>) and share the latest software versions with stakeholders – publicly or privately via your <a href="/features/trust-center/" class="text-purple hover:text-purple-700 underline">Trust Center</a>. No more manual SBOM distribution or version confusion.
                 </p>
 
                 <div class="mb-8">
@@ -110,7 +110,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 <div class="eyebrow-chip mb-5">Trust Center</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Transparency That Builds Trust</h2>
                 <p class="mb-6 text-lg text-secondaryText leading-relaxed">
-                Share SBOMs, compliance documents, and security artifacts with stakeholders in a standardized way. Your <a href="/features/trust-center/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">trust center</a> can be hosted on your own domain and supports both web portal access and standardized SBOM formats for automated consumption. Compliance documents are expressed programmatically alongside your SBOMs.
+                Share SBOMs, compliance documents, and security artifacts with stakeholders in a standardized way. Your <a href="/features/trust-center/" class="text-purple hover:text-purple-700 underline">trust center</a> can be hosted on your own domain and supports both web portal access and standardized SBOM formats for automated consumption. Compliance documents are expressed programmatically alongside your SBOMs.
                 </p>
 
                 <div class="my-12">
@@ -125,7 +125,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 <div class="eyebrow-chip mb-5">Security Artifact Hub</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Store, Analyze & Enrich</h2>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
-                sbomify is designed not only to hold your security artifacts but also to send them off for analysis. We integrate with CI/CD pipelines (GitHub, GitLab, Bitbucket), analysis tools like <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Google OSV</a> and <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Dependency Track</a>, and enrichment platforms such as <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Ecosyste.ms</a>. Your security artifacts flow seamlessly from generation through analysis and enrichment, giving you actionable insights without manual work.
+                sbomify is designed not only to hold your security artifacts but also to send them off for analysis. We integrate with CI/CD pipelines (GitHub, GitLab, Bitbucket), analysis tools like <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Google OSV</a> and <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Dependency Track</a>, and enrichment platforms such as <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Ecosyste.ms</a>. Your security artifacts flow seamlessly from generation through analysis and enrichment, giving you actionable insights without manual work.
                 </p>
 
                 <div class="mb-8">
@@ -136,8 +136,8 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
             </section>
 
             <!-- Trusted By section -->
-            <div class="max-w-4xl mx-auto mb-20 bg-[#201B4C] border border-[#37306B] rounded-2xl px-8 py-10 hover:border-[#8A7DFF] transition-all duration-300 overflow-hidden">
-                <span class="text-[#8A7DFF] text-sm font-semibold uppercase tracking-wide mb-8 block text-center">Trusted By</span>
+            <div class="max-w-4xl mx-auto mb-20 bg-primary-light border border-primary-600 rounded-2xl px-8 py-10 hover:border-purple transition-colors duration-300 overflow-hidden">
+                <span class="text-purple text-sm font-semibold uppercase tracking-wide mb-8 block text-center">Trusted By</span>
                 <div class="relative">
                     <div class="flex items-center justify-center gap-6 md:gap-12 lg:gap-16 h-16">
                         <a href="/case-studies/atsign" class="hover:opacity-80 transition-opacity flex items-center flex-shrink-0">
@@ -157,7 +157,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 The EU's Cyber Resilience Act (CRA) is now in force, with <strong>mandatory reporting starting September 11, 2026</strong>. Whether you sell to European customers or not, CRA compliance is becoming a baseline expectation for B2B software.
                 </p>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
-                Combined with US <a href="https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Executive Order 14028</a> requiring SBOMs for federal procurement, the message is clear: transparency isn't optional anymore. sbomify helps you meet these requirements efficiently, whether you need public trust centers, automated SBOM generation, or compliance reporting.
+                Combined with US <a href="https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity" class="text-purple hover:text-purple-700 underline">Executive Order 14028</a> requiring SBOMs for federal procurement, the message is clear: transparency isn't optional anymore. sbomify helps you meet these requirements efficiently, whether you need public trust centers, automated SBOM generation, or compliance reporting.
                 </p>
                 <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="/features/why-now">Learn More About CRA</a>
             </section>
@@ -172,7 +172,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                     </div>
                 </div>
                 <p class="mb-6 text-lg text-secondaryText leading-relaxed">
-                sbomify gives you the flexibility to run it yourself or let us run it for you. <a href="https://github.com/sbomify/sbomify" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Find us on GitHub</a> to self-host for complete control over your data and infrastructure, or use our managed cloud service for zero-maintenance convenience.
+                sbomify gives you the flexibility to run it yourself or let us run it for you. <a href="https://github.com/sbomify/sbomify" class="text-purple hover:text-purple-700 underline">Find us on GitHub</a> to self-host for complete control over your data and infrastructure, or use our managed cloud service for zero-maintenance convenience.
                 </p>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
                 Either way, you get the same powerful SBOM and compliance document management, support for CycloneDX and SPDX formats, and seamless integrations with your existing tools. No vendor lock-in, no compromises.
@@ -186,7 +186,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
     </div>
     <div class="bg-primaryBG">
         <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
-            <div class="text-sm font-semibold uppercase tracking-wide mb-12 text-[#8A7DFF]">
+            <div class="text-sm font-semibold uppercase tracking-wide mb-12 text-purple">
                 Blog
             </div>
             {{< posts limit="3" dark="true" title="Latest blog posts" >}}
@@ -202,7 +202,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
         if (data.tag_name) {
           var container = document.getElementById('gh-latest-version');
           if (container) {
-            container.innerHTML = '<a href="' + data.html_url + '" target="_blank" class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-[#8A7DFF]/10 border border-[#8A7DFF]/20 hover:bg-[#8A7DFF]/20 transition-colors group no-underline"><span class="relative flex h-2 w-2"><span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span><span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span></span><span class="text-xs font-medium text-[#8A7DFF] group-hover:text-[#7A6DE5]">Release ' + data.tag_name + '</span></a>';
+            container.innerHTML = '<a href="' + data.html_url + '" target="_blank" class="inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple/10 border border-purple/20 hover:bg-purple/20 transition-colors group no-underline"><span class="relative flex h-2 w-2"><span class="animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75"></span><span class="relative inline-flex rounded-full h-2 w-2 bg-green-500"></span></span><span class="text-xs font-medium text-purple group-hover:text-purple-700">Release ' + data.tag_name + '</span></a>';
             container.classList.remove('hidden');
           }
         }

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,12 +7,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
 
 <div>
     <div class="bg-primaryBG relative overflow-hidden">
-        <!-- Animated aurora -->
-        <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-            <div class="aurora aurora-1"></div>
-            <div class="aurora aurora-2"></div>
-            <div class="aurora aurora-3"></div>
-        </div>
+        {{< aurora >}}
         <!-- Soft top vignette to anchor the headline -->
         <div aria-hidden="true" class="absolute inset-0 bg-gradient-to-b from-primaryBG/0 via-primaryBG/0 to-primaryBG/40 pointer-events-none"></div>
 

--- a/content/_index.html
+++ b/content/_index.html
@@ -7,19 +7,28 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
 
 <div>
     <div class="bg-primaryBG relative overflow-hidden">
-        <!-- Subtle gradient overlay -->
-        <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+        <!-- Animated aurora -->
+        <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+            <div class="aurora aurora-1"></div>
+            <div class="aurora aurora-2"></div>
+            <div class="aurora aurora-3"></div>
+        </div>
+        <!-- Soft top vignette to anchor the headline -->
+        <div aria-hidden="true" class="absolute inset-0 bg-gradient-to-b from-primaryBG/0 via-primaryBG/0 to-primaryBG/40 pointer-events-none"></div>
 
         <div class="relative max-w-7xl mx-auto px-6 lg:px-8 pt-16 lg:pt-24 pb-16 lg:pb-20">
             <!-- Hero Section -->
             <div class="text-white mb-16 lg:mb-20 text-center">
-                <h1 class="text-5xl lg:text-7xl font-bold leading-tight mb-8">
+                <h1 class="text-5xl lg:text-7xl font-bold leading-[1.05] tracking-tight mb-8">
                     <span class="text-gradient">Your Security Artifact Hub</span>
-                    </h1>
-                <p class="text-2xl lg:text-3xl leading-relaxed text-gray-300 max-w-4xl mx-auto">From zero to SBOM hero. Generate, manage, and share <a href="/what-is-sbom/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">SBOMs</a> and compliance documents with your stakeholders.</p>
+                </h1>
+                <p class="text-xl lg:text-2xl leading-relaxed text-gray-300 max-w-3xl mx-auto text-pretty">From zero to SBOM hero. Generate, manage, and share <a href="/what-is-sbom/" class="text-purple hover:text-purple-700 underline underline-offset-4 decoration-purple/40 hover:decoration-purple-700">SBOMs</a> and compliance documents with your stakeholders.</p>
                 <div class="mt-10 flex flex-wrap gap-4 justify-center">
-                    <a href="https://app.sbomify.com" class="px-8 py-4 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-semibold text-lg transition-all duration-200">Get Started Free</a>
-                    <a href="https://app.sbomify.com/enterprise-contact/" class="px-8 py-4 bg-[#201B4C] border-2 border-[#37306B] hover:border-[#8A7DFF] text-white rounded-full font-semibold text-lg transition-all duration-200">Contact Us</a>
+                    <a href="https://app.sbomify.com" class="group inline-flex items-center justify-center gap-2 px-8 py-4 bg-purple hover:bg-purple-700 text-white rounded-full font-semibold text-lg shadow-lg shadow-purple/25 hover:shadow-xl hover:shadow-purple/40 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200">
+                        Get Started Free
+                        <svg aria-hidden="true" class="w-4 h-4 motion-safe:group-hover:translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
+                    </a>
+                    <a href="https://app.sbomify.com/enterprise-contact/" class="inline-flex items-center justify-center px-8 py-4 bg-white/5 border border-white/15 hover:bg-white/10 hover:border-white/25 text-white rounded-full font-semibold text-lg backdrop-blur-sm motion-safe:hover:-translate-y-0.5 transition-[background-color,border-color,transform] duration-200">Contact Us</a>
                 </div>
             </div>
 
@@ -88,8 +97,8 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
 
     <div class="bg-[#F6F9FA]">
         <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
-            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-100 shadow-sm">
-                <div class="text-sm font-semibold uppercase tracking-wide mb-4 text-[#8A7DFF]">SBOM Lifecycle Tool</div>
+            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+                <div class="eyebrow-chip mb-5">SBOM Lifecycle Tool</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Zero to SBOM Hero</h2>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
                 Build high-quality SBOMs directly in your CI pipeline with our <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">open source action</a>. Once generated, SBOMs are automatically uploaded to sbomify where you can manage releases (including <a href="/features/sbom-hierarchy/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">complex hierarchies</a>) and share the latest software versions with stakeholders – publicly or privately via your <a href="/features/trust-center/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Trust Center</a>. No more manual SBOM distribution or version confusion.
@@ -99,11 +108,11 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                     <img src="/assets/images/d2/zero-to-hero.svg" alt="Zero to SBOM Hero Process" class="w-full h-auto" width="1140" height="316" loading="lazy">
                 </div>
 
-                <a class="inline-block px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium transition-all duration-200" href="/zero-to-hero/">Get Started</a>
+                <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="/zero-to-hero/">Get Started</a>
             </section>
 
-            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-100 shadow-sm">
-                <div class="text-sm font-semibold uppercase tracking-wide mb-4 text-[#8A7DFF]">Trust Center</div>
+            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+                <div class="eyebrow-chip mb-5">Trust Center</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Transparency That Builds Trust</h2>
                 <p class="mb-6 text-lg text-secondaryText leading-relaxed">
                 Share SBOMs, compliance documents, and security artifacts with stakeholders in a standardized way. Your <a href="/features/trust-center/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">trust center</a> can be hosted on your own domain and supports both web portal access and standardized SBOM formats for automated consumption. Compliance documents are expressed programmatically alongside your SBOMs.
@@ -114,11 +123,11 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 </div>
 
                 {{< trust-center-pillars-grid >}}
-                <a class="inline-block px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium transition-all duration-200" href="/features/trust-center/">Learn More</a>
+                <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="/features/trust-center/">Learn More</a>
             </section>
 
-            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-100 shadow-sm">
-                <div class="text-sm font-semibold uppercase tracking-wide mb-4 text-[#8A7DFF]">Security Artifact Hub</div>
+            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+                <div class="eyebrow-chip mb-5">Security Artifact Hub</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Store, Analyze & Enrich</h2>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
                 sbomify is designed not only to hold your security artifacts but also to send them off for analysis. We integrate with CI/CD pipelines (GitHub, GitLab, Bitbucket), analysis tools like <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Google OSV</a> and <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Dependency Track</a>, and enrichment platforms such as <a href="/features/integrations/" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Ecosyste.ms</a>. Your security artifacts flow seamlessly from generation through analysis and enrichment, giving you actionable insights without manual work.
@@ -128,7 +137,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                     <img src="/assets/images/d2/store-analyze-enrich.svg" alt="Store, Analyze & Enrich Process" class="w-full h-auto" width="1323" height="407" loading="lazy">
                 </div>
 
-                <a class="inline-block px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium transition-all duration-200" href="/features/integrations/">View All Integrations</a>
+                <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="/features/integrations/">View All Integrations</a>
             </section>
 
             <!-- Trusted By section -->
@@ -146,8 +155,8 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 </div>
             </div>
 
-            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-100 shadow-sm">
-                <div class="text-sm font-semibold uppercase tracking-wide mb-4 text-[#8A7DFF]">Why Now?</div>
+            <section class="max-w-4xl mx-auto mb-20 bg-white rounded-3xl p-10 lg:p-12 border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+                <div class="eyebrow-chip mb-5">Why Now?</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">CRA is Coming. Ready or Not.</h2>
                 <p class="mb-6 text-lg text-secondaryText leading-relaxed">
                 The EU's Cyber Resilience Act (CRA) is now in force, with <strong>mandatory reporting starting September 11, 2026</strong>. Whether you sell to European customers or not, CRA compliance is becoming a baseline expectation for B2B software.
@@ -155,11 +164,11 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
                 Combined with US <a href="https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity" class="text-[#8A7DFF] hover:text-[#7A6DE5] underline">Executive Order 14028</a> requiring SBOMs for federal procurement, the message is clear: transparency isn't optional anymore. sbomify helps you meet these requirements efficiently, whether you need public trust centers, automated SBOM generation, or compliance reporting.
                 </p>
-                <a class="inline-block px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium transition-all duration-200" href="/features/why-now">Learn More About CRA</a>
+                <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="/features/why-now">Learn More About CRA</a>
             </section>
 
-            <section class="max-w-4xl mx-auto bg-white rounded-3xl p-10 lg:p-12 border border-gray-100 shadow-sm">
-                <div class="text-sm font-semibold uppercase tracking-wide mb-4 text-[#8A7DFF]">Your Choice, Your Control</div>
+            <section class="max-w-4xl mx-auto bg-white rounded-3xl p-10 lg:p-12 border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+                <div class="eyebrow-chip mb-5">Your Choice, Your Control</div>
                 <div class="flex items-center justify-between flex-wrap gap-4 mb-6">
                     <h2 class="text-4xl lg:text-5xl font-bold text-primaryText">Self-Host or Cloud</h2>
                     <div class="flex items-center gap-3">
@@ -174,8 +183,8 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 Either way, you get the same powerful SBOM and compliance document management, support for CycloneDX and SPDX formats, and seamless integrations with your existing tools. No vendor lock-in, no compromises.
                 </p>
                 <div class="flex gap-4">
-                    <a class="inline-block px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium transition-all duration-200" href="https://app.sbomify.com">Try Cloud Free</a>
-                    <a class="inline-block px-6 py-3 bg-white border-2 border-gray-200 hover:border-[#8A7DFF] text-primaryText rounded-full font-medium transition-all duration-200" href="https://github.com/sbomify/sbomify">Self-Host</a>
+                    <a class="inline-flex items-center px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-medium shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" href="https://app.sbomify.com">Try Cloud Free</a>
+                    <a class="inline-flex items-center px-6 py-3 bg-white border-2 border-gray-200 hover:border-purple text-primaryText rounded-full font-medium motion-safe:hover:-translate-y-0.5 transition-[border-color,transform] duration-200" href="https://github.com/sbomify/sbomify">Self-Host</a>
                 </div>
             </section>
         </div>

--- a/content/_index.html
+++ b/content/_index.html
@@ -201,17 +201,38 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
     function makeEl(tag, className, attrs) {
       var el = document.createElement(tag);
       if (className) el.className = className;
-      if (attrs) for (var k in attrs) el.setAttribute(k, attrs[k]);
+      if (attrs) {
+        var keys = Object.keys(attrs);
+        for (var i = 0; i < keys.length; i++) el.setAttribute(keys[i], attrs[keys[i]]);
+      }
       return el;
     }
 
+    /* Allow only https links to a known sbomify GitHub host on hrefs derived
+       from the API response — defends against javascript: / data: URLs and
+       redirects to unrelated origins. */
+    function safeGithubUrl(url) {
+      if (typeof url !== 'string') return null;
+      try {
+        var parsed = new URL(url);
+        if (parsed.protocol !== 'https:') return null;
+        if (parsed.hostname !== 'github.com' && parsed.hostname !== 'www.github.com') return null;
+        if (parsed.pathname.indexOf('/sbomify/sbomify') !== 0) return null;
+        return parsed.href;
+      } catch (e) {
+        return null;
+      }
+    }
+
     function renderRelease(data) {
-      var container = document.getElementById('gh-latest-version');
-      if (!container || !data || !data.tag_name) return;
+      var slot = document.getElementById('gh-latest-version');
+      if (!slot || !data || !data.tag_name) return;
+      var href = safeGithubUrl(data.html_url);
+      if (!href) return;
 
       var a = makeEl('a',
         'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-purple/10 border border-purple/20 hover:bg-purple/20 transition-colors group no-underline',
-        { href: data.html_url, target: '_blank', rel: 'noopener noreferrer' });
+        { href: href, target: '_blank', rel: 'noopener noreferrer' });
 
       var dot = makeEl('span', 'relative flex h-2 w-2', { 'aria-hidden': 'true' });
       dot.appendChild(makeEl('span', 'animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75'));
@@ -222,13 +243,13 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
       label.textContent = 'Release ' + data.tag_name;
       a.appendChild(label);
 
-      container.replaceChildren(a);
-      container.classList.remove('hidden');
+      slot.replaceChildren(a);
+      slot.classList.remove('hidden');
     }
 
     function renderStars(data) {
-      var container = document.getElementById('gh-star-cta');
-      if (!container || !data || data.stargazers_count === undefined) return;
+      var slot = document.getElementById('gh-star-cta');
+      if (!slot || !data || data.stargazers_count === undefined) return;
 
       var a = makeEl('a',
         'inline-flex items-center gap-2 px-3 py-1 rounded-full bg-gray-900 text-white hover:bg-gray-800 transition-colors no-underline group',
@@ -253,8 +274,8 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
       count.textContent = data.stargazers_count.toLocaleString();
       a.appendChild(count);
 
-      container.replaceChildren(a);
-      container.classList.remove('hidden');
+      slot.replaceChildren(a);
+      slot.classList.remove('hidden');
     }
 
     (window.requestIdleCallback || function(cb) { setTimeout(cb, 1); })(function() {

--- a/content/_index.html
+++ b/content/_index.html
@@ -214,7 +214,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
         { href: data.html_url, target: '_blank', rel: 'noopener noreferrer' });
 
       var dot = makeEl('span', 'relative flex h-2 w-2', { 'aria-hidden': 'true' });
-      dot.appendChild(makeEl('span', 'motion-safe:animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75'));
+      dot.appendChild(makeEl('span', 'animate-ping absolute inline-flex h-full w-full rounded-full bg-green-400 opacity-75'));
       dot.appendChild(makeEl('span', 'relative inline-flex rounded-full h-2 w-2 bg-green-500'));
       a.appendChild(dot);
 

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -19,7 +19,7 @@
         <p class="text-gray-600 text-lg mb-8">
           We couldn't find what you were looking for, but don't worry &mdash; unlike a missing SBOM, this is easy to fix.
         </p>
-        <a href="/" class="inline-block bg-gradient-to-r from-[#6C5CE7] to-[#8A7DFF] text-white font-semibold px-8 py-3 rounded-lg hover:opacity-90 transition-opacity mb-8">
+        <a href="/" class="inline-block bg-gradient-to-r from-purple-700 to-purple text-white font-semibold px-8 py-3 rounded-lg hover:opacity-90 transition-opacity mb-8">
           Take Me Home
         </a>
         <div class="border-t border-gray-100 pt-8">

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/404.html
+++ b/layouts/404.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -25,8 +25,12 @@
 </script>
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -25,12 +25,7 @@
 </script>
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/about.html
+++ b/layouts/_default/about.html
@@ -52,7 +52,7 @@
         <div class="flex flex-col gap-8">
           {{ range $i, $advisor := site.Data.advisors }}
             {{ $mod := mod (add $i 1) 2 }}
-            <div class="bg-white p-8 md:p-10 rounded-2xl shadow-sm border border-gray-100 flex flex-col {{ if eq $mod 0 }}md:flex-row-reverse{{ else }}md:flex-row{{ end }} items-center gap-8 md:gap-12 transition-all duration-300 hover:border-[#8A7DFF]">
+            <div class="bg-white p-8 md:p-10 rounded-2xl shadow-sm border border-gray-100 flex flex-col {{ if eq $mod 0 }}md:flex-row-reverse{{ else }}md:flex-row{{ end }} items-center gap-8 md:gap-12 transition-colors duration-300 hover:border-purple">
 
               <div class="flex-shrink-0">
                 {{ $imgPath := strings.TrimPrefix "/assets/" $advisor.image }}
@@ -77,7 +77,7 @@
                     </a>
                   {{ end }}
                 </div>
-                <p class="text-[#8A7DFF] font-medium text-sm uppercase tracking-wide mb-4">{{ $advisor.role }}</p>
+                <p class="text-purple font-medium text-sm uppercase tracking-wide mb-4">{{ $advisor.role }}</p>
                 <p class="text-secondaryText leading-relaxed mb-0 text-lg">
                   {{ $advisor.bio }}
                 </p>

--- a/layouts/_default/integrations.html
+++ b/layouts/_default/integrations.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/_default/integrations.html
+++ b/layouts/_default/integrations.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,7 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
         <span class="text-gradient">{{ .Title }}</span>

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -11,14 +11,14 @@
   <div class="max-w-7xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-8">
       {{ range .Pages }}
-      <a href="{{ .RelPermalink }}" class="group flex flex-col justify-between rounded-2xl p-8 hover:shadow-xl transition-all duration-300 h-full bg-white border border-gray-200 hover:border-[#8A7DFF]">
+      <a href="{{ .RelPermalink }}" class="group flex flex-col justify-between rounded-2xl p-8 hover:shadow-xl transition-[box-shadow,border-color] duration-300 h-full bg-white border border-gray-200 hover:border-purple">
         <div>
-          <h2 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-[#8A7DFF] transition-colors duration-200 text-primaryText capitalize">
+          <h2 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-purple transition-colors duration-200 text-primaryText capitalize">
             {{ .LinkTitle }}
           </h2>
         </div>
         <div class="flex items-center justify-end pt-6 mt-6 border-t border-gray-100">
-          <span class="text-[#8A7DFF] text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-200">View &rarr;</span>
+          <span class="text-purple text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-200">View &rarr;</span>
         </div>
       </a>
       {{ end }}

--- a/layouts/_default/taxonomy.html
+++ b/layouts/_default/taxonomy.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
         <span class="text-gradient">{{ .Title }}</span>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
         <span class="text-gradient capitalize">{{ .Title }}</span>

--- a/layouts/_default/term.html
+++ b/layouts/_default/term.html
@@ -1,7 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">
         <span class="text-gradient capitalize">{{ .Title }}</span>

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/case-studies/list.html
+++ b/layouts/case-studies/list.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <!-- Content -->
     <div class="relative max-w-4xl mx-auto text-center">

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -35,10 +35,10 @@
         <h3 class="text-2xl font-bold text-primaryText mb-4">Inspired by this story?</h3>
         <p class="text-gray-600 mb-8">See how sbomify can help your team achieve similar results.</p>
         <div class="flex gap-4 justify-center">
-          <a href="https://app.sbomify.com" class="px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-semibold transition-all duration-200 text-base no-underline">
+          <a href="https://app.sbomify.com" class="px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-semibold transition-colors duration-200 text-base no-underline">
             Start Free Trial
           </a>
-          <a href="/case-studies" class="px-6 py-3 bg-white border border-gray-200 hover:border-[#8A7DFF] text-primaryText rounded-full font-semibold transition-all duration-200 text-base no-underline">
+          <a href="/case-studies" class="px-6 py-3 bg-white border border-gray-200 hover:border-purple text-primaryText rounded-full font-semibold transition-colors duration-200 text-base no-underline">
             All Case Studies
           </a>
         </div>

--- a/layouts/case-studies/single.html
+++ b/layouts/case-studies/single.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <!-- Content -->
     <div class="relative max-w-4xl mx-auto text-center">

--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -31,7 +31,7 @@
           id="faq-search"
           placeholder="Search questions..."
           autocomplete="off"
-          class="w-full px-5 py-3 rounded-full border border-gray-200 bg-white text-primaryText placeholder-gray-400 focus:outline-none focus:border-[#8A7DFF] focus:ring-2 focus:ring-[#8A7DFF]/20 transition-all text-base"
+          class="w-full px-5 py-3 rounded-full border border-gray-200 bg-white text-primaryText placeholder-gray-400 focus:outline-none focus:border-purple focus:ring-2 focus:ring-purple/20 transition-[border-color,box-shadow] text-base"
         />
         <p id="faq-count" class="text-sm text-gray-500 mt-3 ml-2 hidden"></p>
       </div>
@@ -39,7 +39,7 @@
       <!-- No results message -->
       <div id="faq-no-results" class="hidden text-center py-12">
         <p class="text-gray-500 text-lg">No questions match your search.</p>
-        <button type="button" onclick="document.getElementById('faq-search').value='';document.getElementById('faq-search').dispatchEvent(new Event('input'));" class="mt-4 text-[#8A7DFF] hover:text-[#7A6DE5] font-semibold text-sm transition-colors">
+        <button type="button" onclick="document.getElementById('faq-search').value='';document.getElementById('faq-search').dispatchEvent(new Event('input'));" class="mt-4 text-purple hover:text-purple-700 font-semibold text-sm transition-colors">
           Clear search
         </button>
       </div>
@@ -49,17 +49,17 @@
         {{ range .Pages.ByWeight }}
         <div class="faq-card bg-white rounded-2xl shadow-sm border border-gray-100 p-8" data-title="{{ .Title | lower }}" data-answer="{{ with .Params.answer }}{{ . | lower }}{{ end }}">
           <h2 class="text-xl lg:text-2xl font-bold text-primaryText mb-3">
-            <a href="{{ .RelPermalink }}" class="hover:text-[#8A7DFF] transition-colors no-underline">
+            <a href="{{ .RelPermalink }}" class="hover:text-purple transition-colors no-underline">
               {{ .Title }}
             </a>
             {{ with .Params.plan }}
-            <span class="inline-block align-middle ml-2 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-[#8A7DFF]/10 text-[#8A7DFF]">{{ . }}</span>
+            <span class="inline-block align-middle ml-2 px-2.5 py-0.5 rounded-full text-xs font-semibold bg-purple/10 text-purple">{{ . }}</span>
             {{ end }}
           </h2>
           {{ with .Params.answer }}
           <p class="text-gray-600 leading-relaxed mb-4">{{ . }}</p>
           {{ end }}
-          <a href="{{ .RelPermalink }}" class="text-[#8A7DFF] hover:text-[#7A6DE5] font-semibold text-sm transition-colors no-underline">
+          <a href="{{ .RelPermalink }}" class="text-purple hover:text-purple-700 font-semibold text-sm transition-colors no-underline">
             Read full answer &rarr;
           </a>
         </div>
@@ -68,7 +68,7 @@
 
       <!-- Show more button -->
       <div id="faq-show-more" class="text-center mt-8 hidden">
-        <button type="button" id="faq-show-more-btn" class="px-8 py-3 bg-white border border-gray-200 hover:border-[#8A7DFF] text-primaryText rounded-full font-semibold transition-all duration-200 text-base">
+        <button type="button" id="faq-show-more-btn" class="px-8 py-3 bg-white border border-gray-200 hover:border-purple text-primaryText rounded-full font-semibold transition-colors duration-200 text-base">
           Show more questions
         </button>
       </div>
@@ -78,10 +78,10 @@
         <h3 class="text-2xl font-bold text-primaryText mb-4">Still have questions?</h3>
         <p class="text-gray-600 mb-8">Our team is here to help you get started with SBOMs and supply chain security.</p>
         <div class="flex gap-4 justify-center flex-wrap">
-          <a href="https://app.sbomify.com" class="px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-semibold transition-all duration-200 text-base no-underline">
+          <a href="https://app.sbomify.com" class="px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-semibold transition-colors duration-200 text-base no-underline">
             Try sbomify Free
           </a>
-          <a href="/blog/" class="px-6 py-3 bg-white border border-gray-200 hover:border-[#8A7DFF] text-primaryText rounded-full font-semibold transition-all duration-200 text-base no-underline">
+          <a href="/blog/" class="px-6 py-3 bg-white border border-gray-200 hover:border-purple text-primaryText rounded-full font-semibold transition-colors duration-200 text-base no-underline">
             Read Our Blog
           </a>
         </div>

--- a/layouts/faq/list.html
+++ b/layouts/faq/list.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <!-- Content -->
     <div class="relative max-w-7xl mx-auto text-center">

--- a/layouts/faq/single.html
+++ b/layouts/faq/single.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <!-- Content -->
     <div class="relative max-w-4xl mx-auto text-center">

--- a/layouts/faq/single.html
+++ b/layouts/faq/single.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <!-- Content -->
     <div class="relative max-w-4xl mx-auto text-center">

--- a/layouts/faq/single.html
+++ b/layouts/faq/single.html
@@ -9,7 +9,7 @@
         <span class="text-gradient">{{ .Title }}</span>
       </h1>
       {{ with .Params.plan }}
-      <span class="inline-block px-4 py-1.5 rounded-full text-sm font-semibold bg-[#8A7DFF]/20 text-[#8A7DFF] border border-[#8A7DFF]/30">{{ . }} plan</span>
+      <span class="inline-block px-4 py-1.5 rounded-full text-sm font-semibold bg-purple/20 text-purple border border-purple/30">{{ . }} plan</span>
       {{ end }}
     </div>
   </div>
@@ -19,9 +19,9 @@
       <!-- Breadcrumb -->
       <nav class="mb-8 text-sm text-gray-500" aria-label="Breadcrumb">
         <ol class="flex items-center gap-2">
-          <li><a href="/" class="hover:text-[#8A7DFF] transition-colors">Home</a></li>
+          <li><a href="/" class="hover:text-purple transition-colors">Home</a></li>
           <li class="text-gray-400">/</li>
-          <li><a href="/faq/" class="hover:text-[#8A7DFF] transition-colors">FAQ</a></li>
+          <li><a href="/faq/" class="hover:text-purple transition-colors">FAQ</a></li>
           <li class="text-gray-400">/</li>
           <li class="text-gray-700">{{ .Title }}</li>
         </ol>
@@ -34,10 +34,10 @@
 
       <!-- Bottom navigation -->
       <div class="mt-12 flex flex-wrap items-center justify-between gap-4">
-        <a href="/faq/" class="text-[#8A7DFF] hover:text-[#7A6DE5] font-semibold transition-colors no-underline">
+        <a href="/faq/" class="text-purple hover:text-purple-700 font-semibold transition-colors no-underline">
           &larr; All FAQ
         </a>
-        <a href="https://app.sbomify.com" class="px-6 py-3 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-semibold transition-all duration-200 text-base no-underline">
+        <a href="https://app.sbomify.com" class="px-6 py-3 bg-purple hover:bg-purple-700 text-white rounded-full font-semibold transition-colors duration-200 text-base no-underline">
           Try sbomify Free
         </a>
       </div>

--- a/layouts/partials/aurora.html
+++ b/layouts/partials/aurora.html
@@ -1,0 +1,7 @@
+<!-- Animated aurora — three drifting radial gradients behind a hero block.
+     Markup is decorative; pair with a relative+overflow-hidden parent. -->
+<div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+  <div class="aurora aurora-1"></div>
+  <div class="aurora aurora-2"></div>
+  <div class="aurora aurora-3"></div>
+</div>

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,4 +1,5 @@
-<footer class="bg-primaryBG border-t border-[#37306B]">
+<footer class="bg-primaryBG relative">
+  <div aria-hidden="true" class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary-600 to-transparent"></div>
   <div class="max-w-7xl mx-auto px-6 lg:px-8 py-12 lg:py-16">
     <div class="flex flex-col lg:flex-row justify-between items-center gap-8">
       <!-- Logo Section -->
@@ -19,15 +20,15 @@
 
       <!-- Links Section -->
       <nav class="flex flex-wrap gap-x-6 gap-y-3 lg:gap-8 text-sm text-tertiaryText flex-[2] justify-center" aria-label="Footer navigation">
-        <a href="/blog/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Blog</a>
-        <a href="/guides/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Guides</a>
-        <a href="/faq/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">FAQ</a>
-        <a href="/case-studies/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Case Studies</a>
-        <a href="/resources/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Resources</a>
-        <a href="/compliance/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Compliance</a>
-        <a href="/pricing/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Pricing</a>
-        <a href="https://trust.sbomify.com/" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap" target="_blank" rel="noopener noreferrer">Trust Center</a>
-        <a href="https://app.sbomify.com" class="hover:text-[#8A7DFF] transition-colors whitespace-nowrap">Login</a>
+        <a href="/blog/" class="hover:text-purple transition-colors whitespace-nowrap">Blog</a>
+        <a href="/guides/" class="hover:text-purple transition-colors whitespace-nowrap">Guides</a>
+        <a href="/faq/" class="hover:text-purple transition-colors whitespace-nowrap">FAQ</a>
+        <a href="/case-studies/" class="hover:text-purple transition-colors whitespace-nowrap">Case Studies</a>
+        <a href="/resources/" class="hover:text-purple transition-colors whitespace-nowrap">Resources</a>
+        <a href="/compliance/" class="hover:text-purple transition-colors whitespace-nowrap">Compliance</a>
+        <a href="/pricing/" class="hover:text-purple transition-colors whitespace-nowrap">Pricing</a>
+        <a href="https://trust.sbomify.com/" class="hover:text-purple transition-colors whitespace-nowrap" target="_blank" rel="noopener noreferrer">Trust Center</a>
+        <a href="https://app.sbomify.com" class="hover:text-purple transition-colors whitespace-nowrap">Login</a>
       </nav>
 
       <!-- Social & Legal Section -->

--- a/layouts/partials/footer.html
+++ b/layouts/partials/footer.html
@@ -1,5 +1,5 @@
 <footer class="bg-primaryBG relative">
-  <div aria-hidden="true" class="absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary-600 to-transparent"></div>
+  <div aria-hidden="true" class="pointer-events-none absolute inset-x-0 top-0 h-px bg-gradient-to-r from-transparent via-primary-600 to-transparent"></div>
   <div class="max-w-7xl mx-auto px-6 lg:px-8 py-12 lg:py-16">
     <div class="flex flex-col lg:flex-row justify-between items-center gap-8">
       <!-- Logo Section -->

--- a/layouts/partials/header.html
+++ b/layouts/partials/header.html
@@ -1,6 +1,6 @@
 <header class="bg-primaryBG sticky top-0 z-50">
   <div class="max-w-7xl mx-auto px-6 py-4">
-    <div class="flex justify-between items-center bg-[#201B4C] rounded-full px-6 py-3 border border-[#37306B]">
+    <div class="flex justify-between items-center bg-primary-light rounded-full px-6 py-3 border border-primary-600">
       <div class="flex gap-10 items-center">
         <a href="/" class="hover:opacity-90 transition-opacity">
           {{ $logo := resources.Get "images/site/logo.svg" }}
@@ -17,7 +17,7 @@
           {{ partial "nav.html" . }}
         </div>
         <div class="hidden lg:block ml-2">
-          <a href="https://app.sbomify.com" class="px-6 py-2.5 bg-[#8A7DFF] hover:bg-[#7A6DE5] text-white rounded-full font-medium text-sm transition-all duration-200 inline-block" onclick="posthog.capture('cta_click', { location: 'header', label: 'Sign Up / Log In' })">Sign Up / Log In</a>
+          <a href="https://app.sbomify.com" class="inline-block px-6 py-2.5 bg-purple hover:bg-purple-700 text-white rounded-full font-medium text-sm shadow-md shadow-purple/20 hover:shadow-lg hover:shadow-purple/30 motion-safe:hover:-translate-y-0.5 transition-[background-color,box-shadow,transform] duration-200" onclick="posthog.capture('cta_click', { location: 'header', label: 'Sign Up / Log In' })">Sign Up / Log In</a>
         </div>
         {{ partial "nav-mobile.html" . }}
       </div>

--- a/layouts/partials/nav.html
+++ b/layouts/partials/nav.html
@@ -1,5 +1,5 @@
 <nav class="hidden lg:flex gap-1" aria-label="Main navigation">
   {{ range site.Data.main.nav }}
-    <a href="{{ .link }}" class="text-white hover:text-[#8A7DFF] hover:bg-[#37306B] transition-all duration-200 font-medium text-sm px-4 py-2 rounded-full">{{ .name }}</a>
+    <a href="{{ .link }}" class="px-4 py-2 rounded-full text-sm font-medium text-white/90 hover:text-white hover:bg-white/5 transition-colors duration-200">{{ .name }}</a>
   {{ end }}
 </nav>

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -7,17 +7,17 @@
 >
   <div class="flex-grow">
     {{ if eq $headingLevel "h2" }}
-    <h2 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-[#8A7DFF] transition-colors duration-200 {{ if $dark }}text-white{{ else }}text-primaryText{{ end }}">
+    <h2 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-purple transition-colors duration-200 {{ if $dark }}text-white{{ else }}text-primaryText{{ end }}">
       {{ $post.Title | truncate 180 }}
     </h2>
     {{ else }}
-    <h3 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-[#8A7DFF] transition-colors duration-200 {{ if $dark }}text-white{{ else }}text-primaryText{{ end }}">
+    <h3 class="text-2xl font-semibold leading-tight mb-4 group-hover:text-purple transition-colors duration-200 {{ if $dark }}text-white{{ else }}text-primaryText{{ end }}">
       {{ $post.Title | truncate 180 }}
     </h3>
     {{ end }}
     <p class="text-base leading-relaxed line-clamp-3 {{ if $dark }}text-gray-300{{ else }}text-secondaryText{{ end }}">{{ $post.Summary | plainify | truncate 140 "..." }}</p>
   </div>
-  <div class="flex items-center justify-between pt-6 mt-6 {{ if $dark }}border-t border-[#37306B]{{ else }}border-t border-gray-100{{ end }}">
+  <div class="flex items-center justify-between pt-6 mt-6 {{ if $dark }}border-t border-primary-600{{ else }}border-t border-gray-100{{ end }}">
     <div class="text-sm {{ if $dark }}text-gray-400{{ else }}text-gray-500{{ end }}">
       {{ with $post.Params.author }}{{ with .display_name }}
       <span class="font-medium {{ if $dark }}text-gray-300{{ else }}text-gray-600{{ end }}">
@@ -29,7 +29,7 @@
         {{ $post.Date.Format "Jan 2. 2006" }}
       </span>
     </div>
-    <span class="text-[#8A7DFF] text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-200">
+    <span class="text-purple text-sm font-medium opacity-0 group-hover:opacity-100 transition-opacity duration-200">
       Read more &rarr;
     </span>
   </div>

--- a/layouts/partials/post-card.html
+++ b/layouts/partials/post-card.html
@@ -3,7 +3,7 @@
 {{- $headingLevel := .headingLevel | default "h3" -}}
 <a
   href="{{ $post.RelPermalink }}"
-  class="group flex flex-col justify-between rounded-2xl p-8 hover:shadow-xl transition-all duration-300 h-full {{ if $dark }}bg-[#201B4C] border border-[#37306B] hover:border-[#8A7DFF]{{ else }}bg-white border border-gray-200 hover:border-[#8A7DFF]{{ end }}"
+  class="group flex flex-col justify-between rounded-2xl p-8 h-full motion-safe:hover:-translate-y-1 hover:shadow-xl transition-[box-shadow,transform,border-color] duration-300 {{ if $dark }}bg-primary-light border border-primary-600 hover:border-purple hover:shadow-purple/20{{ else }}bg-white border border-gray-200 hover:border-purple hover:shadow-purple/10{{ end }}"
 >
   <div class="flex-grow">
     {{ if eq $headingLevel "h2" }}

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/posts/list.html
+++ b/layouts/posts/list.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative px-5 py-16 lg:py-24 lg:px-24 max-w-7xl mx-auto">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,12 +1,7 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Animated aurora -->
-    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
-      <div class="aurora aurora-1"></div>
-      <div class="aurora aurora-2"></div>
-      <div class="aurora aurora-3"></div>
-    </div>
+    {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,8 +1,12 @@
 {{ define "main" }}
 <div>
   <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
-    <!-- Subtle gradient overlay -->
-    <div class="absolute inset-0 bg-gradient-to-br from-[#8A7DFF]/5 via-transparent to-transparent pointer-events-none"></div>
+    <!-- Animated aurora -->
+    <div aria-hidden="true" class="absolute inset-0 pointer-events-none">
+      <div class="aurora aurora-1"></div>
+      <div class="aurora aurora-2"></div>
+      <div class="aurora aurora-3"></div>
+    </div>
 
     <div class="relative max-w-4xl mx-auto text-center">
       <h1 class="text-white text-[40px] lg:text-[68px] leading-[48px] lg:leading-[78px] mb-6">

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -39,7 +39,7 @@
       {{ with .GetTerms "tags" }}
       <div class="flex flex-wrap items-center justify-center gap-2">
         {{ range . }}
-        <a href="{{ .RelPermalink }}" class="px-3 py-1 text-sm bg-[#8A7DFF]/20 text-[#8A7DFF] hover:bg-[#8A7DFF]/30 rounded-full no-underline transition-colors">{{ .LinkTitle }}</a>
+        <a href="{{ .RelPermalink }}" class="px-3 py-1 text-sm bg-purple/20 text-purple hover:bg-purple/30 rounded-full no-underline transition-colors">{{ .LinkTitle }}</a>
         {{ end }}
       </div>
       {{ end }}
@@ -53,7 +53,7 @@
         {{ .Content }}
         <div class="mt-12 pt-8 border-t border-gray-200">
           <p class="text-sm text-gray-500 italic">
-            Found an error or typo? File a PR against <a href="https://github.com/sbomify/sbomify.com/tree/master/{{ .File.Path }}" rel="nofollow" class="text-[#8A7DFF] hover:text-[#7A6DE5] no-underline">this file</a>.
+            Found an error or typo? File a PR against <a href="https://github.com/sbomify/sbomify.com/tree/master/{{ .File.Path }}" rel="nofollow" class="text-purple hover:text-purple-700 no-underline">this file</a>.
           </p>
         </div>
       </article>

--- a/layouts/shortcodes/aurora.html
+++ b/layouts/shortcodes/aurora.html
@@ -1,0 +1,1 @@
+{{ partial "aurora.html" . }}

--- a/layouts/shortcodes/author-photo.html
+++ b/layouts/shortcodes/author-photo.html
@@ -4,12 +4,12 @@
 {{- $img := resources.Get $src -}}
 {{- if $img -}}
   {{- $dim := "256x256" -}}
-  {{- $class := "w-32 h-32 object-cover !m-0 grayscale hover:grayscale-0 transition-all duration-500" -}}
+  {{- $class := "w-32 h-32 object-cover !m-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" -}}
   {{- $w := 128 -}}
   {{- $h := 128 -}}
   {{- if eq $size "leader" -}}
     {{- $dim = "448x448" -}}
-    {{- $class = "w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" -}}
+    {{- $class = "w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" -}}
     {{- $w = 224 -}}
     {{- $h = 224 -}}
   {{- end -}}
@@ -19,5 +19,5 @@
     <img src="{{ $img.RelPermalink }}" alt="{{ $name }}" class="{{ $class }}" width="{{ $w }}" height="{{ $h }}" loading="lazy">
   </picture>
 {{- else -}}
-  <img src="/assets/{{ $src }}" alt="{{ $name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
+  <img src="/assets/{{ $src }}" alt="{{ $name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
 {{- end -}}

--- a/layouts/shortcodes/author-photo.html
+++ b/layouts/shortcodes/author-photo.html
@@ -4,12 +4,12 @@
 {{- $img := resources.Get $src -}}
 {{- if $img -}}
   {{- $dim := "256x256" -}}
-  {{- $class := "w-32 h-32 object-cover !m-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" -}}
+  {{- $class := "w-32 h-32 object-cover !m-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-[filter] duration-500" -}}
   {{- $w := 128 -}}
   {{- $h := 128 -}}
   {{- if eq $size "leader" -}}
     {{- $dim = "448x448" -}}
-    {{- $class = "w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" -}}
+    {{- $class = "w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-[filter] duration-500" -}}
     {{- $w = 224 -}}
     {{- $h = 224 -}}
   {{- end -}}
@@ -19,5 +19,5 @@
     <img src="{{ $img.RelPermalink }}" alt="{{ $name }}" class="{{ $class }}" width="{{ $w }}" height="{{ $h }}" loading="lazy">
   </picture>
 {{- else -}}
-  <img src="/assets/{{ $src }}" alt="{{ $name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-all duration-500" width="224" height="224" loading="lazy">
+  <img src="/assets/{{ $src }}" alt="{{ $name }}" class="w-48 h-48 md:w-56 md:h-56 object-cover !mb-0 !mt-0 !rounded-none !shadow-none grayscale hover:grayscale-0 transition-[filter] duration-500" width="224" height="224" loading="lazy">
 {{- end -}}

--- a/layouts/shortcodes/feature-card.html
+++ b/layouts/shortcodes/feature-card.html
@@ -1,8 +1,8 @@
-<div class="bg-white p-8 rounded-3xl border border-gray-100 shadow-sm hover:shadow-md transition-all group">
-    <div class="w-14 h-14 {{ .Get "icon_bg_class" }} rounded-2xl flex items-center justify-center {{ .Get "icon_text_class" }} mb-6 group-hover:scale-110 transition-transform duration-300">
+<div class="group bg-white p-8 rounded-3xl border border-gray-200/70 ring-1 ring-black/[0.02] shadow-[0_1px_3px_rgba(20,16,53,0.04),0_8px_24px_-12px_rgba(20,16,53,0.08)] hover:shadow-[0_1px_3px_rgba(20,16,53,0.04),0_24px_48px_-16px_rgba(138,125,255,0.18)] hover:border-purple/20 motion-safe:hover:-translate-y-1 transition-[box-shadow,transform,border-color] duration-300">
+    <div class="w-14 h-14 {{ .Get "icon_bg_class" }} rounded-2xl flex items-center justify-center {{ .Get "icon_text_class" }} mb-6 motion-safe:group-hover:scale-110 transition-transform duration-300">
         {{ if .Get "svg" }}{{ .Get "svg" | safeHTML }}{{ else }}{{ .Inner | safeHTML }}{{ end }}
     </div>
-    <h3 class="text-2xl font-bold text-[#201B4C] mb-4">{{ .Get "title" }}</h3>
+    <h3 class="text-2xl font-bold text-primary-light mb-4">{{ .Get "title" }}</h3>
     <p class="text-secondaryText leading-relaxed">
         {{ .Get "description" | safeHTML }}
     </p>


### PR DESCRIPTION
## Summary

A conservative modernization pass across the marketing site — visible upgrades without changing structure or content. CSS additions plus class refactors. No new fonts and no new image assets — perfect-PageSpeed budget preserved.

### Visible changes

- **Animated aurora hero** — three drifting radial-gradient orbs behind every page title (CSS-only, `prefers-reduced-motion` safe). Centralised in `layouts/partials/aurora.html` (+ shortcode wrapper for content files) so future tweaks land in one place.
- **Eyebrow chips** on homepage section labels (chip + dot + brand color) replacing plain uppercase text
- **Layered card shadows** with a brand-purple glow on hover for homepage section cards; motion-safe hover-lift on CTAs and post cards
- **Hero CTA** gains an arrow icon that nudges right on hover; secondary CTA reworked as glass-style with `bg-white/5`
- **Footer** hard top border replaced with a soft gradient hairline (now `pointer-events-none + aria-hidden`)

### Typography & a11y

- Inter Variable stylistic alternates via `font-feature-settings`
- Negative letter-spacing on display headings, `text-wrap: balance` on h1–h6, `text-wrap: pretty` on paragraphs
- `-webkit-font-smoothing: antialiased`, `text-rendering: optimizeLegibility`
- Brand-purple `::selection` styling
- `scroll-behavior: smooth` and `scroll-padding-top: 6rem` (smooth-scroll gated behind `@media (prefers-reduced-motion: no-preference)`)
- Aurora animation + `will-change: transform` also gated behind no-preference (no idle GPU layer for reduced-motion users)
- Global `@media (prefers-reduced-motion: reduce)` override on Tailwind's `.animate-ping/.animate-pulse/.animate-spin/.animate-bounce` so any built-in keyframe utility is respected even when the call site can't apply `motion-safe:`
- All transforms gated behind `motion-safe:` modifier

### Tailwind hygiene

- Migrated arbitrary `[#201B4C]` / `[#37306B]` / `[#8A7DFF]` / `[#7A6DE5]` to named theme tokens (`primary-light`, `primary-600`, `purple`, `purple-700`) across all PR-touched templates
- Replaced `transition-all` with scoped `transition-colors` / `transition-[border-color,box-shadow]` / `transition-[background-color,box-shadow,transform]` / `transition-[filter]`
- Used `inline-flex items-center` for CTAs, `aria-hidden` on decorative elements

### Bug fix

- `.page img` rule was rounding & drop-shadowing author photos inside `<article class="page">`, stacking corners against the parent card. Fixed via `!rounded-none !shadow-none` in the `author-photo` shortcode.

### JS refactor (homepage GitHub fetch)

The pre-existing inline script in `content/_index.html` that injects "Latest release" and "Star count" chips from `api.github.com` was rebuilt to use `document.createElement` + `textContent` instead of string-concatenated `innerHTML`. API-derived values (`data.html_url`, `data.tag_name`, `data.stargazers_count`) now flow through DOM APIs instead of HTML parsing — XSS surface eliminated. Both `target="_blank"` links also gain `rel="noopener noreferrer"`. No new behaviour, just safer construction.

## Test plan

- [ ] Verify aurora renders & drifts on `/`, `/blog/`, `/about/`, `/case-studies/`, `/faq/`, individual blog post, single FAQ entry, taxonomy/term pages, and 404
- [ ] Confirm `prefers-reduced-motion: reduce` halts the aurora animation, smooth-scroll, and the GitHub release ping dot
- [ ] Hover all homepage CTAs and section cards → subtle lift + brand-purple shadow
- [ ] Verify Viktor's photo on `/about/` no longer has stacked rounded corners
- [ ] Check eyebrow chips on the five homepage section cards
- [ ] PageSpeed Insights mobile + desktop should remain at/near 100
- [ ] Verify the homepage GitHub release/star widgets still render correctly with the new DOM-API approach

🤖 Generated with [Claude Code](https://claude.com/claude-code)