### PR TITLE
content(blog): announce v26.1.0 and v26.2.0 releases

### DIFF
--- a/content/posts/2026-04-02-announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver.md
+++ b/content/posts/2026-04-02-announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver.md
@@ -1,0 +1,93 @@
+---
+title: "Announcing sbomify v26.1.0: The One Where We Switch to CalVer"
+description: "sbomify v26.1.0 introduces the CRA Compliance Wizard, switches to CalVer versioning, adds Trust Center subdomain routing, and brings full TEA v0.4.0 compatibility."
+author:
+  display_name: Viktor Petersson
+categories:
+  - announcement
+tags: [sbom, release, calver, cra, tea, trust-center]
+tldr: "sbomify v26.1.0 introduces the CRA Compliance Wizard so EU device manufacturers can start working through their Cyber Resilience Act readiness inside the product. It also switches to CalVer versioning, brings Trust Center subdomain routing for branded customer-facing pages, adds RFC 9116 security.txt support, and upgrades to TEA spec v0.4.0."
+date: 2026-04-02
+slug: announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver
+---
+
+If you have been following along, you may have noticed the version number just made a fairly dramatic jump, going from v0.27 straight to v26.1.0. That is not a typo. Starting with this release, sbomify is on [CalVer](https://calver.org/).
+
+The short version: a version number should tell you something useful. With CalVer, every release encodes the year it shipped. The `26` is 2026. At a glance, you can tell whether the sbomify version you are running was cut this year, last year, or two years ago. For a security and compliance product, where currency of the software you are running is itself part of the trust signal, that feels like the right thing to optimise for.
+
+That is the only "breaking change" in this release, and it only matters if you have automated version pins pointed at our images. Everything else is additive.
+
+---
+
+## The CRA Compliance Wizard
+
+The headline feature of v26.1.0 is the new **CRA Compliance Wizard**, a guided workflow for assessing your readiness against the [EU Cyber Resilience Act](/compliance/eu-cra/).
+
+The CRA starts biting in 2027, and the most common question we get from device manufacturers is some variation of *"how do I even know if my product is in scope, and what do I need to do about it?"* The wizard walks you through that, step by step:
+
+1. **Scope screening.** Figure out whether your product is in scope for the CRA at all, and if so, whether it falls under the standard, important, or critical category.
+2. **Fix guidance.** When the BSI plugin flags missing or malformed fields in your SBOM, the wizard tells you exactly which fields need attention and where, rather than just handing you a failed assessment.
+
+This is the first half of a longer CRA workflow we have been building. The full Declaration of Conformity, with manufacturer signature and PDF export, lands in the very next release. But the scope screening and fix guidance are usable today, and they alone should save device teams a lot of late-night spec reading.
+
+You can open the wizard from any product page.
+
+---
+
+## Trust Center on Your Own Subdomain
+
+The Trust Center is where your customers go to find your SBOMs, compliance assessments, and security contact information. Until now, you could either keep it at `sbomify.com/<your-workspace>` or attach a custom domain. v26.1.0 adds a third option: you can serve it from a **subdomain of your own domain**, like `trust.example.com`.
+
+Combined with custom-domain support, the Trust Center now feels like a native part of your own web presence rather than a third-party portal that happens to host your documents.
+
+---
+
+## RFC 9116 `security.txt`
+
+[RFC 9116](https://www.rfc-editor.org/rfc/rfc9116) is the standard for telling security researchers where to send a vulnerability disclosure. It lives at a well-known path on your domain, and most coordinated-disclosure tooling looks for it automatically.
+
+With v26.1.0, every Trust Center page automatically serves a valid `security.txt` populated from your workspace's security contact details. Researchers who want to responsibly report an issue can now find out how, without having to dig through your website.
+
+---
+
+## Transparency Exchange API (TEA) v0.4.0
+
+We have been contributors to the [Transparency Exchange API](https://github.com/CycloneDX/transparency-exchange-api) since it was a draft, and we shipped the first version of TEA support in v0.27 (["The One with TEA"](/2026/02/24/announcing-sbomify-v0-27-the-one-with-tea/)). The spec has continued to evolve since then, and v26.1.0 brings sbomify up to **TEA spec v0.4.0**.
+
+For you, this mostly means three things:
+
+- **Better release representation.** Components, releases, and the SBOMs attached to each release are now represented as separate concepts in your TEA endpoint, which matches how downstream consumers expect to find them.
+- **Build-variant support.** The same release built for different architectures or operating systems can now be represented unambiguously.
+- **Faster TEA endpoints.** Downstream consumers polling your TEA endpoint will see much lower latencies thanks to caching.
+
+If you are publishing SBOMs to customers or partners via TEA, this release should land transparently. If you are consuming someone else's TEA endpoint, you will get richer data without changing anything on your end.
+
+---
+
+## A Broader Definition of "BOM"
+
+We started with SBOMs. The industry is now also producing Hardware BOMs, AI-BOMs, ML-BOMs, and operations BOMs, and we expect more BOM types to follow. To stop bolting each one on as a separate feature, we have generalised the data model so all BOM types flow through the same workflows: the same plugins, the same Trust Center, the same TEA endpoints, the same lifecycle tracking.
+
+Your existing SBOMs keep working without any change on your part. As we add support for new BOM formats over the next few quarters, they will slot in cleanly alongside what you already have.
+
+---
+
+## A Few Smaller Things
+
+- **CycloneDX 1.7** uploads are now accepted, alongside all the older versions you were already using.
+- **Plugins moved to the sidebar.** They were previously buried under Settings and people kept asking where they were. They are now one click from anywhere.
+- **PostHog analytics** on the hosted platform, so we can see which features people actually reach for. Self-hosted operators can disable it.
+- **Hardened production images.** Our production Docker images now use Chainguard's distroless Python base, which means a smaller attack surface for self-hosted deployments. Shoutout to [@nissessenap](https://github.com/nissessenap) for doing the legwork on this migration.
+- **Better support for tricky network environments.** TLS with custom CA certificates and Redis password authentication are now fully supported for self-hosted deployments behind corporate proxies.
+
+---
+
+## Getting Started
+
+If you are on the **hosted platform**, everything is already live, no action needed. The CRA Compliance Wizard is available from any product page. To switch your Trust Center over to a subdomain, head to **Settings → Trust Center**.
+
+For **self-hosted** deployments, pull the new image and update. Take a database snapshot before you upgrade, as the BOM-model migration is irreversible.
+
+For the full technical detail, including the complete list of bug fixes, dependency upgrades, and self-hosted infrastructure changes, see the [v26.1.0 release notes on GitHub](https://github.com/sbomify/sbomify/releases/tag/v26.1.0).
+
+As always, I would love to hear your feedback. If anything about the CalVer change or the CRA Wizard is confusing, open a support ticket from inside [the app](https://app.sbomify.com) and the team will get back to you.

--- a/content/posts/2026-04-02-announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver.md
+++ b/content/posts/2026-04-02-announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver.md
@@ -23,7 +23,7 @@ That is the only "breaking change" in this release, and it only matters if you h
 
 The headline feature of v26.1.0 is the new **CRA Compliance Wizard**, a guided workflow for assessing your readiness against the [EU Cyber Resilience Act](/compliance/eu-cra/).
 
-The CRA starts biting in 2027, and the most common question we get from device manufacturers is some variation of *"how do I even know if my product is in scope, and what do I need to do about it?"* The wizard walks you through that, step by step:
+The CRA starts biting in 2027, and the most common question we get from device manufacturers is some variation of _"how do I even know if my product is in scope, and what do I need to do about it?"_ The wizard walks you through that, step by step:
 
 1. **Scope screening.** Figure out whether your product is in scope for the CRA at all, and if so, whether it falls under the standard, important, or critical category.
 2. **Fix guidance.** When the BSI plugin flags missing or malformed fields in your SBOM, the wizard tells you exactly which fields need attention and where, rather than just handing you a failed assessment.

--- a/content/posts/2026-05-13-announcing-sbomify-v26-2-0-the-one-that-signs-the-doc.md
+++ b/content/posts/2026-05-13-announcing-sbomify-v26-2-0-the-one-that-signs-the-doc.md
@@ -1,0 +1,96 @@
+---
+title: "Announcing sbomify v26.2.0: The One That Signs the DoC"
+description: "sbomify v26.2.0 completes the EU CRA workflow with a signed Declaration of Conformity, adds Component Lifecycle Events, SBOM signatures and provenance, and full CycloneDX 1.7 / SPDX 3.0.1 support."
+author:
+  display_name: Viktor Petersson
+categories:
+  - announcement
+tags: [sbom, release, cra, compliance, tea, sigstore, provenance]
+tldr: "sbomify v26.2.0 finishes the EU Cyber Resilience Act workflow we started in v26.1.0. You can now generate a Declaration of Conformity inside sbomify, sign it with a real handwritten signature, optionally seal the bundle with sigstore, and publish it directly to your product's public page. We have also added Component Lifecycle Events for tracking when products reach end of life, SBOM signatures and provenance for proving where your SBOMs came from, and broader format support across CycloneDX and SPDX."
+date: 2026-05-13
+slug: announcing-sbomify-v26-2-0-the-one-that-signs-the-doc
+---
+
+In [v26.1.0](/2026/04/02/announcing-sbomify-v26-1-0-the-one-where-we-switch-to-calver/) we shipped the first half of the EU Cyber Resilience Act workflow: figuring out whether you are in scope, and what you need to fix. v26.2.0 is where we close the loop. You can now generate a signed Declaration of Conformity straight from sbomify, and publish it on your product's public page in front of customers and regulators.
+
+## The Declaration of Conformity, End to End
+
+If you are putting a product on the EU market under the CRA, you need a [Declaration of Conformity](/compliance/eu-cra/). It is the document where you, the manufacturer, formally state that your product meets the regulation's requirements. Customers want it. Distributors want it. Regulators absolutely want it.
+
+With v26.2.0, you can produce one inside sbomify, end to end. The CRA Compliance Wizard now covers the full workflow:
+
+1. **Scope screening.** Figure out whether your product is in scope. *(shipped in v26.1.0)*
+2. **Fix guidance.** Resolve any SBOM gaps that would block conformity. *(shipped in v26.1.0)*
+3. **EN 18031 opt-in.** If your product is in scope for the harmonised radio equipment standards, layer EN 18031-1/2/3 assessment on top. *(new in v26.2.0)*
+4. **Sign the DoC.** Generate the Declaration of Conformity, capture a manufacturer signature directly in the browser (no DocuSign required), and export it as a PDF. Optionally seal the whole bundle with a sigstore signature for cryptographic provenance. *(new in v26.2.0)*
+5. **Publish.** The resulting DoC is available on your product's public page, ready to share with customers and regulators with a single link. *(new in v26.2.0)*
+
+We have also added a **stale-assessment guard**. If your SBOM has been updated since the last CRA assessment, the wizard surfaces a banner so you do not accidentally publish a DoC against outdated evidence.
+
+If you have a hardware product heading into the EU market in 2027, this is the workflow we built for you.
+
+---
+
+## Component Lifecycle Events
+
+Knowing when a product or component reaches end of support or end of life is critical for both customers and your own internal planning. In v0.25 we introduced lifecycle dates on products and components. With v26.2.0, we have made those a first-class concept.
+
+**Component Lifecycle Events** capture the full history of a product's life: when it was released, when it enters its mainstream support phase, when it goes into extended support, and when it finally reaches end of life. Each transition is recorded as an event, with a date and a context, rather than just a single static date field.
+
+For you, this means:
+
+- **History instead of state.** You can see how a product's lifecycle has evolved over time, not just where it is right now.
+- **Automatic publication.** A new public endpoint on your Trust Center exposes these events, so customers and downstream tooling can subscribe to lifecycle changes the same way they already pull SBOMs.
+- **No manual work.** Your existing release-date and end-of-life fields have been migrated automatically. You do not need to do anything.
+
+If you are tracking the lifecycle of a Linux distribution, a runtime, a library, or your own product, you now have a standard way to consume and propagate that signal.
+
+---
+
+## SBOM Signatures and Provenance
+
+An SBOM tells you what is in your software. A signed SBOM tells you where it came from and that nobody has tampered with it.
+
+v26.2.0 adds first-class support for **SBOM signatures and provenance attestations**. If you generate signed SBOMs from your CI/CD pipeline using [sbomify-action](https://github.com/sbomify/sbomify-action), sbomify will now:
+
+- **Verify the signature** automatically on upload, using [Sigstore](https://www.sigstore.dev/), the same infrastructure that powers supply-chain security across the open source ecosystem.
+- **Display a Signed badge** on the SBOM detail page when a valid signature is present.
+- **Display a Provenance badge** when an in-toto-style provenance attestation is attached.
+- **Show both badges in your Trust Center.** Customers looking at your public SBOM listings will see at a glance which artifacts are cryptographically verified.
+
+The trust signal is now visible inside your own dashboards and outside in front of customers.
+
+---
+
+## More SBOMs Will Just Work
+
+We have always been format-agnostic on uploads, but format support has been quietly broadening. With v26.2.0 we now accept:
+
+- **CycloneDX 1.3, 1.4, 1.5, 1.6, and 1.7**
+- **SPDX 2.2, 2.3, and 3.0.1**
+
+We have also relaxed two strict-validation rules that were tripping up real-world SBOMs from upstream tooling: CycloneDX SBOMs without a `metadata.component` field are now accepted, and so are SPDX 3.0.1 SBOMs without a top-level document name. Both are technically permitted by the respective specs, but several SBOM generators omit them in practice.
+
+If you have ever had an SBOM rejected by sbomify because of a missing field that you cannot control, this release likely fixes it for you.
+
+---
+
+## A Friendlier First Login
+
+A few smaller things that add up:
+
+- **Workspace hierarchy in the empty dashboard.** New workspaces now render a clickable hierarchy tree (Workspace → Product → Component → SBOM) so it is immediately obvious how the pieces fit together. Click anywhere on the tree to start creating the first one.
+- **Onboarding drip emails.** New users now receive a series of targeted tips after sign-up, rather than a single welcome message followed by silence.
+- **Redesigned emails.** Notification emails have been rebuilt from scratch, with full dark-mode support. Email clients finally caught up.
+
+---
+
+## Getting Started
+
+If you are on the **hosted platform**, everything in this release is already live, no action needed. The CRA Compliance Wizard is available from any product page, and your existing lifecycle dates have already been migrated into the new Component Lifecycle Events model.
+
+For **self-hosted** deployments, pull `ghcr.io/sbomify/sbomify:v26.2.0` and update. Take a database snapshot before you upgrade, as there is a real data migration in this release.
+
+For the full technical detail, including the complete list of bug fixes, dependency upgrades, and the under-the-hood plugin and infrastructure changes, see the [v26.2.0 release notes on GitHub](https://github.com/sbomify/sbomify/releases/tag/v26.2.0).
+
+As always, I would love to hear your feedback. If you are working through the CRA Compliance Wizard and something is confusing, or worse, missing, open a support ticket from inside [the app](https://app.sbomify.com) and the team will get back to you. The whole point of building this in the open is so we can fix the rough edges before the regulation actually starts to bite.

--- a/content/posts/2026-05-13-announcing-sbomify-v26-2-0-the-one-that-signs-the-doc.md
+++ b/content/posts/2026-05-13-announcing-sbomify-v26-2-0-the-one-that-signs-the-doc.md
@@ -19,11 +19,11 @@ If you are putting a product on the EU market under the CRA, you need a [Declara
 
 With v26.2.0, you can produce one inside sbomify, end to end. The CRA Compliance Wizard now covers the full workflow:
 
-1. **Scope screening.** Figure out whether your product is in scope. *(shipped in v26.1.0)*
-2. **Fix guidance.** Resolve any SBOM gaps that would block conformity. *(shipped in v26.1.0)*
-3. **EN 18031 opt-in.** If your product is in scope for the harmonised radio equipment standards, layer EN 18031-1/2/3 assessment on top. *(new in v26.2.0)*
-4. **Sign the DoC.** Generate the Declaration of Conformity, capture a manufacturer signature directly in the browser (no DocuSign required), and export it as a PDF. Optionally seal the whole bundle with a sigstore signature for cryptographic provenance. *(new in v26.2.0)*
-5. **Publish.** The resulting DoC is available on your product's public page, ready to share with customers and regulators with a single link. *(new in v26.2.0)*
+1. **Scope screening.** Figure out whether your product is in scope. _(shipped in v26.1.0)_
+2. **Fix guidance.** Resolve any SBOM gaps that would block conformity. _(shipped in v26.1.0)_
+3. **EN 18031 opt-in.** If your product is in scope for the harmonised radio equipment standards, layer EN 18031-1/2/3 assessment on top. _(new in v26.2.0)_
+4. **Sign the DoC.** Generate the Declaration of Conformity, capture a manufacturer signature directly in the browser (no DocuSign required), and export it as a PDF. Optionally seal the whole bundle with a sigstore signature for cryptographic provenance. _(new in v26.2.0)_
+5. **Publish.** The resulting DoC is available on your product's public page, ready to share with customers and regulators with a single link. _(new in v26.2.0)_
 
 We have also added a **stale-assessment guard**. If your SBOM has been updated since the last CRA assessment, the wizard surfaces a banner so you do not accidentally publish a DoC against outdated evidence.
 


### PR DESCRIPTION
## Summary

Adds end-user-facing release announcements for two unannounced sbomify releases:

- **v26.1.0 — The One Where We Switch to CalVer** (dated 2026-04-02, the actual release date). Covers the CalVer switch, the initial CRA Compliance Wizard (scope screening + BSI fix guidance), Trust Center subdomain routing, RFC 9116 `security.txt`, TEA spec v0.4.0, and the generalised BOM model.
- **v26.2.0 — The One That Signs the DoC** (dated 2026-05-13). Closes the CRA loop with end-to-end Declaration of Conformity (EN 18031 opt-in, in-browser signature, sigstore-sealed bundle, public DoC page), Component Lifecycle Events, SBOM signatures and provenance, and broader CycloneDX 1.3–1.7 / SPDX 2.2–3.0.1 format coverage.

Both posts:
- Are written for end users. Deep technical details (bug fixes, dependency upgrades, plugin internals, CI hardening) are linked out to the GitHub release notes rather than inlined.
- Direct support requests to in-app tickets at `app.sbomify.com`, not GitHub Issues.
- Have been verified locally: all 11 internal + external links return 200, no em-dashes, both posts render cleanly on the dev server.

## Test plan

- [ ] Local Hugo dev server renders both posts at their permalinks without errors.
- [ ] Blog index (`/blog/`) lists both posts in the correct chronological position.
- [ ] All outbound links (GitHub releases, calver.org, sigstore.dev, app.sbomify.com, etc.) resolve.
- [ ] CI lint (`bun run lint`) passes.
- [ ] Hugo production build (`hugo --minify --environment production`) succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)