### PR TITLE
ci: publish SBOMs via OIDC trusted publishing instead of API token

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -68,13 +68,16 @@ jobs:
   sbom-javascript:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
       - name: Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: 'XalR981KPFba'
           COMPONENT_NAME: 'Marketing Site (JavaScript)'
           COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('{0}-{1}', github.ref_name, github.sha) }}
@@ -86,6 +89,9 @@ jobs:
   sbom-hugo:
     if: github.event_name != 'schedule'
     runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
     steps:
       - uses: actions/checkout@v4
 
@@ -100,7 +106,7 @@ jobs:
       - name: Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
+          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: 'jtYGL1IMu1gQ'
           COMPONENT_NAME: 'Marketing Site (Hugo)'
           COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('{0}-{1}', github.ref_name, github.sha) }}

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -77,7 +77,6 @@ jobs:
       - name: Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: 'XalR981KPFba'
           COMPONENT_NAME: 'Marketing Site (JavaScript)'
           COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('{0}-{1}', github.ref_name, github.sha) }}
@@ -106,7 +105,6 @@ jobs:
       - name: Upload SBOM
         uses: sbomify/sbomify-action@master
         env:
-          OIDC_AUDIENCE: sbomify.com
           COMPONENT_ID: 'jtYGL1IMu1gQ'
           COMPONENT_NAME: 'Marketing Site (Hugo)'
           COMPONENT_VERSION: ${{ github.ref_type == 'tag' && github.ref_name || format('{0}-{1}', github.ref_name, github.sha) }}


### PR DESCRIPTION
**Draft** — part of the org-wide migration of our own SBOM uploads from API tokens to GitHub OIDC trusted publishing.

## What changed
`deploy.yml` — the `sbom-javascript` and `sbom-hugo` jobs switch from `TOKEN: ${{ secrets.SBOMIFY_TOKEN }}` to OIDC:
- **added** `permissions: id-token: write` + `contents: read` to both jobs (they previously inherited none, so the action couldn't mint a GitHub OIDC token)
- **dropped** the `SBOMIFY_TOKEN` secret

No auth env vars remain: the action auto-detects OIDC from the `id-token: write` permission (via `ACTIONS_ID_TOKEN_REQUEST_URL/TOKEN`) and the audience defaults to `sbomify.com` in the action, so it isn't set here. `COMPONENT_ID` and all other inputs unchanged.

## Blockers
1. ~~OIDC clock-skew fix deployed to prod (sbomify#1012)~~ — **done**: #1012 merged 2026-06-11 (`3239205`), live in prod.
2. **Bindings on app.sbomify.com** for `sbomify/sbomify.com`:
   - `XalR981KPFba` (Marketing Site / JavaScript)
   - `jtYGL1IMu1gQ` (Marketing Site / Hugo)

   Confirm both exist, then un-draft. This is the only remaining gate.

## Verify after merge
A push runs both jobs; confirm each binding's "Last used" flips and the SBOM appears. Then retire the `SBOMIFY_TOKEN` secret here.

