### PR TITLE
fix(seo): resolve Semrush Site Audit findings

### DIFF
--- a/content/authors/_index.md
+++ b/content/authors/_index.md
@@ -1,0 +1,4 @@
+---
+title: Authors
+description: "Meet the authors behind the sbomify blog: practitioners writing about SBOMs, software supply chain security, and compliance."
+---

--- a/content/faq/what-is-an-sbom.md
+++ b/content/faq/what-is-an-sbom.md
@@ -1,5 +1,5 @@
 ---
-title: "What is an SBOM?"
+title: "What is an SBOM (Software Bill of Materials)?"
 description: "Learn what a Software Bill of Materials (SBOM) is, why it matters for supply chain security, and how it lists every component in your software."
 answer: "An SBOM (Software Bill of Materials) is a machine-readable inventory of all components, libraries, and dependencies that make up a piece of software - like an ingredients list for your code."
 tldr: "An SBOM (Software Bill of Materials) is a machine-readable inventory of all components, libraries, and dependencies that make up a piece of software - like an ingredients list for your code."

--- a/content/features/why-now.md
+++ b/content/features/why-now.md
@@ -1,6 +1,7 @@
 ---
 
 title: The Growing Importance of SBOMs in Cybersecurity Compliance
+description: "Why SBOMs matter now: Executive Order 14028, the EU Cyber Resilience Act, PCI DSS 4.0, and the FDA are turning SBOMs into a baseline compliance requirement across industries."
 ---
 
 The cybersecurity landscape has evolved rapidly in recent years, driven largely by increased awareness of software supply chain vulnerabilities. A significant milestone in this evolution was the US government's introduction of [Executive Order 14028](https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity) in May 2021. This executive order responded directly to escalating cyber threats targeting critical infrastructure, government agencies, and private enterprises. One of its key components mandated Software Bill of Materials (SBOMs) for all vendors selling software to the federal government.

--- a/content/posts/_index.md
+++ b/content/posts/_index.md
@@ -1,3 +1,4 @@
 ---
-title: "sbomify | the SBOM sharing and collaboration platform"
+title: "The sbomify Blog"
+description: "Articles, guides, and product updates on SBOMs, software supply chain security, and compliance from the sbomify team."
 ---

--- a/content/what-is-sbom.md
+++ b/content/what-is-sbom.md
@@ -1,6 +1,7 @@
 ---
 url: /what-is-sbom/
 title: What is an SBOM?
+description: "A Software Bill of Materials (SBOM) is a machine-readable inventory of every component, library, and dependency in your software. Learn what SBOMs are, why regulations require them, and how to get started."
 tldr: "A Software Bill of Materials (SBOM) is a machine-readable inventory of every component, library, and dependency in your software. Think of it as an ingredients list for code. SBOMs are increasingly required by regulations like the EU Cyber Resilience Act and US Executive Order 14028, and are essential for vulnerability management, license compliance, and supply chain security."
 ---
 

--- a/layouts/_default/_markup/render-codeblock.html
+++ b/layouts/_default/_markup/render-codeblock.html
@@ -1,0 +1,2 @@
+{{- $result := transform.HighlightCodeBlock . -}}
+<figure class="code-block">{{ $result.Wrapped }}</figure>

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div>
-  <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
+  <header class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
     {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
@@ -13,15 +13,15 @@
       </p>
       {{ end }}
     </div>
-  </div>
+  </header>
 
-  <div class="bg-[#F6F9FA]">
+  <section class="bg-[#F6F9FA]">
     <div class="max-w-4xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <article class="page bg-white p-8 md:p-12 rounded-2xl shadow-sm border border-gray-100">
         {{ partial "tldr.html" . }}
         {{ .Content }}
       </article>
     </div>
-  </div>
+  </section>
 </div>
 {{ end }}

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -88,19 +88,27 @@
     "sameAs": [
       {{ range $i, $p := site.Params.social.profiles }}{{ if $i }},{{ end }}"{{ $p.url }}"{{ end }}
     ],
-    "description": {{ site.Params.description | jsonify }}
+    "description": {{ site.Params.description | jsonify | safeJS }}
   }
   </script>
 
-  <!-- Schema.org structured data: SoftwareApplication -->
+  {{ if .IsHome }}
+  <!-- Schema.org structured data: Product (Google requires aggregateRating or
+       review on SoftwareApplication; Product validates with offers alone) -->
   <script type="application/ld+json">
   {
     "@context": "https://schema.org",
-    "@type": "SoftwareApplication",
+    "@type": "Product",
+    "additionalType": "https://schema.org/SoftwareApplication",
     "name": "sbomify",
-    "applicationCategory": "BusinessApplication",
-    "applicationSubCategory": "Supply Chain Security",
-    "operatingSystem": "Cloud",
+    "description": {{ site.Params.description | jsonify | safeJS }},
+    "url": "{{ site.BaseURL }}",
+    "image": "{{ site.BaseURL }}android-chrome-512x512.png",
+    "brand": {
+      "@type": "Organization",
+      "name": "sbomify"
+    },
+    "category": "Supply Chain Security Software",
     "offers": [
       {
         "@type": "Offer",
@@ -108,7 +116,8 @@
         "price": "0",
         "priceCurrency": "USD",
         "description": "For OSS maintainers and hobby projects",
-        "availability": "https://schema.org/InStock"
+        "availability": "https://schema.org/InStock",
+        "url": "{{ site.BaseURL }}pricing/"
       },
       {
         "@type": "Offer",
@@ -117,27 +126,13 @@
         "priceCurrency": "USD",
         "description": "For mid-size teams needing private SBOMs",
         "availability": "https://schema.org/InStock",
-        "priceValidUntil": "{{ now.AddDate 0 1 0 | time.Format "2006-01-02" }}"
-      },
-      {
-        "@type": "Offer",
-        "name": "Enterprise",
-        "description": "For large orgs with advanced security & compliance needs. Contact for pricing.",
-        "availability": "https://schema.org/InStock"
+        "priceValidUntil": "{{ now.AddDate 0 1 0 | time.Format "2006-01-02" }}",
+        "url": "{{ site.BaseURL }}pricing/"
       }
-    ],
-    "description": {{ site.Params.description | jsonify }},
-    "url": "{{ site.BaseURL }}",
-    "featureList": [
-      "SBOM Generation",
-      "SBOM Management",
-      "Supply Chain Security",
-      "Compliance Management",
-      "Vulnerability Tracking"
-    ],
-    "softwareVersion": "1.0"
+    ]
   }
   </script>
+  {{ end }}
 
   {{ if eq .Type "posts" }}
   <!-- Schema.org structured data: BlogPosting / TechArticle -->
@@ -156,8 +151,8 @@
       "@type": "WebPage",
       "@id": "{{ .Permalink }}"
     },
-    "headline": {{ .Title | jsonify }},
-    "description": {{ (.Params.description | default site.Params.description) | jsonify }},
+    "headline": {{ .Title | jsonify | safeJS }},
+    "description": {{ (.Params.description | default site.Params.description) | jsonify | safeJS }},
     "image": "{{ $ogImage | absURL }}",
     "author": {
       "@type": "Person",
@@ -210,7 +205,7 @@
       {
         "@type": "ListItem",
         "position": 3,
-        "name": {{ .Title | jsonify }},
+        "name": {{ .Title | jsonify | safeJS }},
         "item": "{{ .Permalink }}"
       }
     ]
@@ -224,8 +219,8 @@
   {
     "@context": "https://schema.org",
     "@type": "Article",
-    "headline": {{ .Title | jsonify }},
-    "description": {{ (.Params.description | default site.Params.description) | jsonify }},
+    "headline": {{ .Title | jsonify | safeJS }},
+    "description": {{ (.Params.description | default site.Params.description) | jsonify | safeJS }},
     "image": "{{ (.Params.logo | default site.Params.social.image) | absURL }}",
     "publisher": {
       "@type": "Organization",
@@ -265,7 +260,7 @@
       {
         "@type": "ListItem",
         "position": 3,
-        "name": {{ .Title | jsonify }},
+        "name": {{ .Title | jsonify | safeJS }},
         "item": "{{ .Permalink }}"
       }
     ]
@@ -283,10 +278,10 @@
       {{ range $i, $qa := .Params.faq }}
       {{ if $i }},{{ end }}{
         "@type": "Question",
-        "name": {{ $qa.question | jsonify }},
+        "name": {{ $qa.question | jsonify | safeJS }},
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": {{ $qa.answer | jsonify }}
+          "text": {{ $qa.answer | jsonify | safeJS }}
         }
       }
       {{ end }}
@@ -311,8 +306,8 @@
   {
     "@context": "https://schema.org",
     "@type": "TechArticle",
-    "name": {{ .Title | jsonify }},
-    "description": {{ (.Params.description | default site.Params.description) | jsonify }},
+    "name": {{ .Title | jsonify | safeJS }},
+    "description": {{ (.Params.description | default site.Params.description) | jsonify | safeJS }},
     "image": "{{ $ogImage | absURL }}",
     "proficiencyLevel": "Beginner",
     "inLanguage": "en-US"
@@ -411,10 +406,10 @@
       {{ range $i, $faq := .Pages.ByWeight }}
       {{ if $i }},{{ end }}{
         "@type": "Question",
-        "name": {{ $faq.Title | jsonify }},
+        "name": {{ $faq.Title | jsonify | safeJS }},
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": {{ $faq.Params.answer | jsonify }}
+          "text": {{ $faq.Params.answer | jsonify | safeJS }}
         }
       }
       {{ end }}
@@ -438,7 +433,7 @@
           "@type": "ListItem",
           "position": {{ add $i 1 }},
           "url": "{{ $faq.Permalink }}",
-          "name": {{ $faq.Title | jsonify }}
+          "name": {{ $faq.Title | jsonify | safeJS }}
         }
         {{ end }}
       ]
@@ -478,10 +473,10 @@
     "mainEntity": [
       {
         "@type": "Question",
-        "name": {{ .Title | jsonify }},
+        "name": {{ .Title | jsonify | safeJS }},
         "acceptedAnswer": {
           "@type": "Answer",
-          "text": {{ .Params.answer | jsonify }}
+          "text": {{ .Params.answer | jsonify | safeJS }}
         }
       }
     ]
@@ -493,8 +488,8 @@
   {
     "@context": "https://schema.org",
     "@type": "WebPage",
-    "name": {{ .Title | jsonify }},
-    "description": {{ (.Params.description | default site.Params.description) | jsonify }},
+    "name": {{ .Title | jsonify | safeJS }},
+    "description": {{ (.Params.description | default site.Params.description) | jsonify | safeJS }},
     "url": "{{ .Permalink }}",
     "dateModified": "{{ .Lastmod.Format "2006-01-02T15:04:05Z07:00" }}",
     "isPartOf": {
@@ -534,7 +529,7 @@
       {
         "@type": "ListItem",
         "position": 3,
-        "name": {{ .Title | jsonify }},
+        "name": {{ .Title | jsonify | safeJS }},
         "item": "{{ .Permalink }}"
       }
     ]

--- a/layouts/partials/head.html
+++ b/layouts/partials/head.html
@@ -1,22 +1,58 @@
 <head>
+  {{- /* Paginated pages (/blog/page/2/ etc.) need their own canonical URL,
+       title, and description so they don't count as duplicates of page 1. */ -}}
+  {{- $paginator := partial "paginator.html" . -}}
+  {{- $pageSuffix := "" -}}
+  {{- $canonical := .Permalink -}}
+  {{- with $paginator -}}
+    {{- if gt .PageNumber 1 -}}
+      {{- $pageSuffix = printf " - Page %d of %d" .PageNumber .TotalPages -}}
+      {{- $canonical = .URL | absURL -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $desc := or .Params.description "" -}}
+  {{- if not $desc -}}
+    {{- if eq .Kind "term" -}}
+      {{- if eq .Data.Plural "categories" -}}
+        {{- $desc = printf "All sbomify blog posts in the %s category: articles on SBOMs, software supply chain security, and compliance." (.Title | lower) -}}
+      {{- else -}}
+        {{- $desc = printf "All sbomify blog posts tagged %s: articles on SBOMs, software supply chain security, and compliance." (.Title | lower) -}}
+      {{- end -}}
+    {{- else if eq .Kind "taxonomy" -}}
+      {{- $desc = printf "Browse the sbomify blog by %s to find articles on SBOMs, software supply chain security, and compliance." (.Title | lower) -}}
+    {{- else -}}
+      {{- $desc = site.Params.description -}}
+    {{- end -}}
+  {{- end -}}
+  {{- $desc = printf "%s%s" $desc $pageSuffix -}}
+  {{- /* Distinguish term page titles from same-named content pages
+       (e.g. /tags/integrations/ vs /features/integrations/). */ -}}
+  {{- $title := .Title -}}
+  {{- if eq .Kind "term" -}}
+    {{- if eq .Data.Plural "categories" -}}
+      {{- $title = printf "%s Category" .Title -}}
+    {{- else -}}
+      {{- $title = printf "%s Articles" .Title -}}
+    {{- end -}}
+  {{- end -}}
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>{{ if eq .RelPermalink "/" }}{{ .Title | default site.Title }}{{ else }}{{ .Title }} | {{ site.Title }}{{ end }}</title>
-  <meta name="description" content="{{ .Params.description | default site.Params.description }}">
+  <title>{{ if eq .RelPermalink "/" }}{{ $title | default site.Title }}{{ else }}{{ $title }}{{ $pageSuffix }} | {{ site.Title }}{{ end }}</title>
+  <meta name="description" content="{{ $desc }}">
   <meta name="keywords" content="{{ with .Params.keywords }}{{ delimit . ", " }}{{ else }}{{ delimit site.Params.keywords ", " }}{{ end }}">
 
   <!-- Canonical URL -->
-  <link rel="canonical" href="{{ .Permalink }}">
+  <link rel="canonical" href="{{ $canonical }}">
 
   <!-- Robots meta -->
   <meta name="robots" content="index, follow">
   <meta name="googlebot" content="index, follow">
 
   <!-- Open Graph Meta Tags -->
-  <meta property="og:title" content="{{ .Title | default site.Title }}">
-  <meta property="og:description" content="{{ .Params.description | default site.Params.description }}">
+  <meta property="og:title" content="{{ $title | default site.Title }}{{ $pageSuffix }}">
+  <meta property="og:description" content="{{ $desc }}">
   <meta property="og:type" content="{{ if eq .Type "posts" }}article{{ else }}website{{ end }}">
-  <meta property="og:url" content="{{ .Permalink }}">
+  <meta property="og:url" content="{{ $canonical }}">
   {{- $ogImage := .Params.image | default site.Params.social.image -}}
   <meta property="og:image" content="{{ $ogImage | absURL }}">
   <meta property="og:image:width" content="1200">
@@ -38,8 +74,8 @@
 
   <!-- Twitter Card Meta Tags -->
   <meta name="twitter:card" content="summary_large_image">
-  <meta name="twitter:title" content="{{ .Title | default site.Title }}">
-  <meta name="twitter:description" content="{{ .Params.description | default site.Params.description }}">
+  <meta name="twitter:title" content="{{ $title | default site.Title }}{{ $pageSuffix }}">
+  <meta name="twitter:description" content="{{ $desc }}">
   <meta name="twitter:image" content="{{ $ogImage | absURL }}">
   <meta name="twitter:image:alt" content="{{ .Title | default site.Title }}">
   {{- $twitterHandle := "" -}}
@@ -51,8 +87,8 @@
 
   <!-- LinkedIn Card Meta Tags -->
   <meta property="linkedin:card" content="summary_large_image">
-  <meta property="linkedin:title" content="{{ .Title | default site.Title }}">
-  <meta property="linkedin:description" content="{{ .Params.description | default site.Params.description }}">
+  <meta property="linkedin:title" content="{{ $title | default site.Title }}{{ $pageSuffix }}">
+  <meta property="linkedin:description" content="{{ $desc }}">
   <meta property="linkedin:image" content="{{ $ogImage | absURL }}">
   <meta property="linkedin:author" content="{{ $linkedinUrl }}">
 

--- a/layouts/partials/pagination.html
+++ b/layouts/partials/pagination.html
@@ -1,6 +1,6 @@
 {{ $paginator := .Paginator }}
 
-<div class="flex justify-center items-center gap-4">
+<nav class="flex justify-center items-center gap-4" aria-label="Pagination">
   {{ if $paginator.HasPrev }}
     <a href="{{ $paginator.Prev.URL }}" class="px-8 py-3 bg-white border border-gray-200 hover:border-[#8A7DFF] text-primaryText hover:text-[#8A7DFF] rounded-full font-medium transition-all duration-200">&larr; Previous</a>
   {{ else }}
@@ -14,4 +14,4 @@
   {{ else }}
     <span class="px-8 py-3 bg-gray-100 border border-gray-200 text-gray-400 rounded-full font-medium cursor-not-allowed">Next &rarr;</span>
   {{ end }}
-</div>
+</nav>

--- a/layouts/partials/paginator.html
+++ b/layouts/partials/paginator.html
@@ -1,0 +1,15 @@
+{{- /* Returns the page's paginator for paginated list pages, or "" otherwise.
+     Mirrors the .Paginate calls in posts.html (via posts/list.html and
+     authors/list.html) and term.html: Hugo errors if .Paginate is invoked
+     with different arguments for the same page, so keep these in sync. */ -}}
+{{- $paginator := "" -}}
+{{- if eq .Kind "term" -}}
+  {{- $paginator = .Paginate .Pages -}}
+{{- else if and (eq .Kind "section") (eq .Section "posts") -}}
+  {{- $paginator = .Paginate (where site.RegularPages "Section" "posts") -}}
+{{- else if and (eq .Kind "section") .Params.author_key -}}
+  {{- with index site.Data.authors .Params.author_key -}}
+    {{- $paginator = $.Paginate (where (where site.RegularPages "Section" "posts") ".Params.author.display_name" .display_name) -}}
+  {{- end -}}
+{{- end -}}
+{{- return $paginator -}}

--- a/layouts/partials/tldr.html
+++ b/layouts/partials/tldr.html
@@ -1,6 +1,6 @@
 {{ if .Params.tldr }}
-<div class="tldr">
+<aside class="tldr">
   <span class="tldr-label">TL;DR</span>
   <p>{{ .Params.tldr }}</p>
-</div>
+</aside>
 {{ end }}

--- a/layouts/posts/single.html
+++ b/layouts/posts/single.html
@@ -1,6 +1,6 @@
 {{ define "main" }}
 <div>
-  <div class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
+  <header class="bg-primaryBG relative overflow-hidden px-5 py-16 lg:py-24 lg:px-24">
     {{ partial "aurora.html" . }}
 
     <div class="relative max-w-4xl mx-auto text-center">
@@ -44,9 +44,9 @@
       </div>
       {{ end }}
     </div>
-  </div>
+  </header>
 
-  <div class="bg-[#F6F9FA]">
+  <section class="bg-[#F6F9FA]">
     <div class="max-w-4xl mx-auto px-6 lg:px-8 py-16 lg:py-24">
       <article class="blog-post bg-white p-8 md:p-12 rounded-2xl shadow-sm border border-gray-100">
         {{ partial "tldr.html" . }}
@@ -58,15 +58,15 @@
         </div>
       </article>
     </div>
-  </div>
+  </section>
 </div>
 
-<div class=" bg-primaryBG">
+<aside class=" bg-primaryBG">
   <div class="max-container text-white px-5 md:px-12 lg:px-24 py-12 lg:py-24">
     <div class="uppercase text-sm mb-4">
       &gt; Blog
     </div>
     {{ partial "posts.html" (dict "limit" 3 "dark" true "hideViewAll" true "title" "Recent Posts" "context" .) }}
   </div>
-</div>
+</aside>
 {{ end }}


### PR DESCRIPTION
## Summary

Fixes three Semrush Site Audit findings: 55 invalid structured data items, duplicate meta descriptions, and low semantic HTML usage.

### 1. Invalid structured data (55 items)

All shared one error: *"A value for the aggregateRating or review field is required"* on the SoftwareApplication schema, which was emitted on every page. Since sbomify has no published reviews to reference (fabricating one risks a Google spam penalty):

- **Convert `SoftwareApplication` to `Product`** with `additionalType: SoftwareApplication`. Google's product snippet rules accept `offers` alone, so it validates without ratings.
- **Emit it on the homepage only** instead of site-wide.
- **Drop the price-less Enterprise offer** (an `Offer` without `price` is itself invalid). Community ($0) and Business ($199) remain.
- **Fix double-encoded JSON-LD strings**: every `jsonify` in the structured data was re-escaped by Hugo's JS-context escaping, leaving stray literal quotes in every headline, description, and FAQ answer. Added `| safeJS` to all 20 occurrences.

### 2. Duplicate meta descriptions

141 pages (tag/category terms, blog and author pagination, `/blog/`, `/authors/`, and a few content pages) fell back to the site-wide default description.

- Generate descriptive fallbacks for term and taxonomy pages ("All sbomify blog posts tagged X...").
- Give paginated pages a self-referencing canonical URL plus a "Page N of M" suffix on title and description, via a new `paginator.html` partial that mirrors the list templates' `.Paginate` calls.
- Add real descriptions to `/blog/`, `/what-is-sbom/`, `/features/why-now/`, and a new `/authors/` section index.
- Disambiguate term page titles (`/tags/integrations/` was titled identically to `/features/integrations/`) and the what-is-an-sbom FAQ title.

### 3. Low semantic HTML usage

Chroma syntax highlighting emits hundreds of token `<span>`s per code block, so code-heavy guide pages scored ~1% semantic elements.

- Wrap fenced code blocks in `<figure>` via a Hugo render hook (Chroma output preserved inside, so styling is unchanged).
- Use `<header>`/`<section>`/`<aside>`/`<nav>` for the page hero, content wrapper, TL;DR block, recent-posts block, and pagination controls.

## Verification

Full production build: all 992 JSON-LD blocks across 317 pages parse as valid JSON, zero duplicate meta descriptions, zero duplicate titles (excluding alias redirect stubs), and guide page semantic-element ratios up from ~0.7% to ~2.5-3.5% (homepage level). `dprint` markdown lint passes.

## Out of scope

Several flagged URLs are on trust.sbomify.com, which emits its own schema and has no meta descriptions at all - it needs equivalent fixes in that codebase.

🤖 Generated with [Claude Code](https://claude.com/claude-code)