### PR TITLE
Update site content for Feb-Jul 2026 product features

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1551,6 +1551,11 @@ a.button:hover {
   border-color: rgb(55 48 107 / var(--tw-border-opacity, 1));
 }
 
+.border-\[\#8A7DFF\] {
+  --tw-border-opacity: 1;
+  border-color: rgb(138 125 255 / var(--tw-border-opacity, 1));
+}
+
 .border-\[\#8A7DFF\]\/20 {
   border-color: rgb(138 125 255 / 0.2);
 }

--- a/content/_index.html
+++ b/content/_index.html
@@ -102,7 +102,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                     <a href="/features/integrations/" class="group bg-white rounded-2xl p-6 border border-gray-200/70 hover:border-purple/30 hover:shadow-[0_8px_24px_-12px_rgba(138,125,255,0.18)] motion-safe:hover:-translate-y-0.5 transition-[transform,border-color,box-shadow] duration-200">
                         <div class="text-purple text-xs font-semibold uppercase tracking-wide mb-2">For Engineers</div>
                         <p class="text-primaryText font-semibold mb-1">Generate in CI, ship with every release</p>
-                        <p class="text-sm text-secondaryText">14 languages, GitHub / GitLab / Bitbucket, open-source action.</p>
+                        <p class="text-sm text-secondaryText">14 ecosystems, tokenless OIDC publishing, guided setup wizard, open-source action.</p>
                         <span class="inline-block mt-3 text-sm text-purple group-hover:text-purple-700 font-medium">Integrations &rarr;</span>
                     </a>
                     <a href="/features/trust-center/" class="group bg-white rounded-2xl p-6 border border-gray-200/70 hover:border-purple/30 hover:shadow-[0_8px_24px_-12px_rgba(138,125,255,0.18)] motion-safe:hover:-translate-y-0.5 transition-[transform,border-color,box-shadow] duration-200">
@@ -141,7 +141,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 Send a link instead of scheduling a call — and cut security questionnaire response times from weeks to minutes.
                 </p>
                 <p class="mb-6 text-lg text-secondaryText leading-relaxed">
-                Share SBOMs, compliance documents, and security artifacts with stakeholders in a standardized way. Your <a href="/features/trust-center/" class="text-purple hover:text-purple-700 underline">trust center</a> can be hosted on your own domain and supports both web portal access and standardized SBOM formats for automated consumption. Compliance documents are expressed programmatically alongside your SBOMs.
+                Share SBOMs, VEX, CBOMs, compliance documents, and security artifacts with stakeholders in a standardized way. Your <a href="/features/trust-center/" class="text-purple hover:text-purple-700 underline">trust center</a> can be hosted on your own domain and supports web portal access, standardized SBOM formats, and the Transparency Exchange API (TEA) for automated consumption. Compliance documents are expressed programmatically alongside your SBOMs.
                 </p>
 
                 <div class="my-12">
@@ -156,7 +156,7 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                 <div class="eyebrow-chip mb-5">Security Artifact Hub</div>
                 <h2 class="text-4xl lg:text-5xl font-bold mb-6 text-primaryText">Store, Analyze & Enrich</h2>
                 <p class="mb-8 text-lg text-secondaryText leading-relaxed">
-                sbomify is designed not only to hold your security artifacts but also to send them off for analysis. We integrate with CI/CD pipelines (GitHub, GitLab, Bitbucket), analysis tools like <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Google OSV</a> and <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Dependency Track</a>, and enrichment platforms such as <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Ecosyste.ms</a>. Your security artifacts flow seamlessly from generation through analysis and enrichment, giving you actionable insights without manual work.
+                sbomify is designed not only to hold your security artifacts but also to send them off for analysis. We integrate with CI/CD pipelines (GitHub, GitLab, Bitbucket), analysis tools like <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Google OSV</a> and <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Dependency Track</a>, and enrichment platforms such as <a href="/features/integrations/" class="text-purple hover:text-purple-700 underline">Ecosyste.ms</a>. Your security artifacts flow seamlessly from generation through analysis and enrichment, giving you actionable insights without manual work. Scan results are <a href="/faq/how-do-i-use-vex/" class="text-purple hover:text-purple-700 underline">VEX-aware</a>, so your not-affected decisions suppress noise in OSV and Dependency Track findings, and cryptographic assets are inventoried as <a href="/faq/what-is-a-cbom/" class="text-purple hover:text-purple-700 underline">CBOMs</a> with a post-quantum readiness view.
                 </p>
 
                 <div class="mb-8">

--- a/content/compliance/ntia-minimum-elements.md
+++ b/content/compliance/ntia-minimum-elements.md
@@ -1,6 +1,8 @@
 ---
 
 url: /compliance/ntia-minimum-elements/
+aliases:
+  - /compliance/ntia/
 title: "NTIA Minimum Elements for SBOM (2021)"
 description: "Complete guide to the NTIA Minimum Elements for a Software Bill of Materials, the foundational US baseline for SBOM data fields."
 section: compliance

--- a/content/faq/are-sboms-required-for-secure-by-design.md
+++ b/content/faq/are-sboms-required-for-secure-by-design.md
@@ -36,7 +36,7 @@ Several major frameworks now connect Secure by Design directly to SBOM requireme
 - **US Executive Order 14028** - directs federal agencies to require SBOMs from software suppliers, with NIST's Secure Software Development Framework (SSDF) reinforcing this
 - **DoD/Pentagon** - requires SBOMs in all new software contracts as of February 2025
 
-For detailed compliance guidance, see our pages on [EU CRA compliance](/compliance/eu-cra/), [NTIA minimum elements](/compliance/ntia/), and [CISA framing](/compliance/cisa-framing/).
+For detailed compliance guidance, see our pages on [EU CRA compliance](/compliance/eu-cra/), [NTIA minimum elements](/compliance/ntia-minimum-elements/), and [CISA framing](/compliance/cisa-framing/).
 
 ## How sbomify helps
 
@@ -45,6 +45,6 @@ sbomify provides the tooling to put Secure by Design into practice:
 - **Generate and manage SBOMs** across your entire product portfolio using [sbomify-action](https://github.com/sbomify/sbomify-action)
 - **Automated vulnerability scanning** against known CVEs so you can respond to disclosures immediately
 - **Share compliance artifacts** with customers and auditors via your [Trust Center](https://trust.sbomify.com/)
-- **Track compliance** against [NTIA](/compliance/ntia/), [CISA](/compliance/cisa-framing/), and [CRA](/compliance/eu-cra/) requirements with built-in compliance plugins
+- **Track compliance** against [NTIA](/compliance/ntia-minimum-elements/), [CISA](/compliance/cisa-framing/), and [CRA](/compliance/eu-cra/) requirements with built-in compliance plugins
 
 Get started for free at [app.sbomify.com](https://app.sbomify.com).

--- a/content/faq/can-i-combine-multiple-sboms-into-one.md
+++ b/content/faq/can-i-combine-multiple-sboms-into-one.md
@@ -23,7 +23,7 @@ Consider a product with a Python backend and a Node frontend, each with its own 
 
 ## What about SPDX 3 and CycloneDX 2?
 
-The latest versions of both formats (SPDX 3.0, which is the current version, and the upcoming CycloneDX 2.0) do support linking multiple documents together without losing context. They allow referencing external SBOM documents while preserving the relationship between components and their source. However, this is significantly more complex than simply concatenating files, and tooling support is still maturing.
+The latest versions of both formats (SPDX 3.0, which is the current version, and the upcoming CycloneDX 2.0) do support linking multiple documents together without losing context. They allow referencing external SBOM documents while preserving the relationship between components and their source. sbomify uses this natively: aggregated release SBOMs emit SPDX 2.3 external document references and SPDX 3.0 import maps, so each component SBOM keeps its identity while the release-level SBOM ties them together.
 
 ## Our recommendation: link, don't merge
 

--- a/content/faq/how-do-i-enable-vulnerability-scanning.md
+++ b/content/faq/how-do-i-enable-vulnerability-scanning.md
@@ -38,7 +38,12 @@ sbomify periodically re-scans your SBOMs as vulnerability databases are updated.
 
 {{< video-embed-native video_url="https://marketing-assets.sbomify.com/screencasts/plugin_enablement_dependency-track.webm" title="Enabling the Dependency Track plugin in sbomify" description="Step-by-step screencast showing how to enable the OWASP Dependency Track plugin in sbomify." >}}
 
+## VEX-aware results
+
+Scan results are not just a raw CVE dump. If you have uploaded [VEX documents](/faq/how-do-i-use-vex/) or triaged findings in sbomify, your `not_affected` statements suppress those findings in both the OSV and Dependency Track results, so the dashboard shows your actual exposure. Findings listed in the CISA Known Exploited Vulnerabilities (KEV) catalog are flagged so you can prioritize the vulnerabilities attackers actually use, and the in-app triage workflow supports bulk decisions with a dry-run preview before anything is committed.
+
 ## Further reading
 
+- [How do I use VEX with sbomify?](/faq/how-do-i-use-vex/)
 - [Integrations - Vulnerability Analysis](/features/integrations/#vulnerability-analysis)
 - [sbomify-action Dependency Track configuration](https://github.com/sbomify/sbomify-action#dependency-track-configuration)

--- a/content/faq/how-do-i-generate-an-sbom.md
+++ b/content/faq/how-do-i-generate-an-sbom.md
@@ -1,16 +1,27 @@
 ---
 title: "How do I generate an SBOM?"
 description: "Step-by-step guide to generating your first SBOM using sbomify-action, open-source tools, and CI/CD integration."
-answer: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. You can also use standalone tools like Syft, ~~Trivy~~ (compromised March 2026), or cdxgen."
-tldr: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. You can also use standalone tools like Syft, ~~Trivy~~ (compromised March 2026), or cdxgen."
+answer: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action init) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
+tldr: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action init) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
 weight: 60
 keywords: [generate SBOM, create SBOM, SBOM tools, SBOM generation, how to SBOM, sbomify-action]
 url: /faq/how-do-i-generate-an-sbom/
 ---
 
+## Fastest path: the setup wizard
+
+If you are starting from scratch, run the interactive [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/) in your repository:
+
+```bash
+pip install sbomify-action
+sbomify-action init
+```
+
+The wizard scans your repo for lockfiles, signs you in to sbomify, creates your product and components, registers [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/), and writes a ready-to-commit `.github/workflows/sboms.yml`. Commit the file and your next push generates and uploads an SBOM.
+
 ## Recommended: sbomify-action
 
-The [sbomify-action](https://github.com/sbomify/sbomify-action) is a CI/CD tool that generates, augments, enriches, and uploads SBOMs from your lockfiles or Docker images. It works as a GitHub Action, Docker image, or pip package, and includes SBOM generators (Syft, ~~Trivy~~, cdxgen) pre-installed. (Note: Trivy was [removed from sbomify-action](/2026/03/26/trivy-compromise-hardening-sbomify-action/) as of v26.1.0 following its March 2026 compromise.)
+The [sbomify-action](https://github.com/sbomify/sbomify-action) is a CI/CD tool that generates, augments, enriches, and uploads SBOMs from your lockfiles or Docker images. It works as a GitHub Action, Docker image, or pip package, and includes SBOM generators (Syft, cdxgen, and native ecosystem tools) pre-installed.
 
 ```yaml
 - uses: sbomify/sbomify-action@master
@@ -20,7 +31,7 @@ The [sbomify-action](https://github.com/sbomify/sbomify-action) is a CI/CD tool 
     ENRICH: true
 ```
 
-sbomify-action supports Python, Node, Rust, Go, Ruby, Dart, C++, Docker images, and Yocto/OpenEmbedded builds. It outputs both CycloneDX and SPDX formats.
+sbomify-action supports 14 ecosystems (Python, JavaScript, Java, Go, Rust, Ruby, PHP, .NET, Swift, Dart, Elixir, Scala, C++, and Terraform), plus Docker images and Yocto/OpenEmbedded builds. It outputs both CycloneDX and SPDX formats.
 
 Beyond basic generation, sbomify-action can:
 
@@ -44,21 +55,18 @@ docker run --rm \
   -e OUTPUT_FILE=/github/workspace/sbom.cdx.json \
   -e UPLOAD=false \
   -e ENRICH=true \
-  sbomifyhub/sbomify-action
+  ghcr.io/sbomify/sbomify-action
 ```
 
 This is useful for local development, scripted workflows, or CI systems that don't have a native sbomify-action integration.
 
 ## Standalone tools
 
-If you prefer standalone tools outside of CI/CD, **Syft** and **~~Trivy~~** are popular options:
+If you prefer standalone tools outside of CI/CD, **Syft** is a popular option:
 
 ```bash
 # Using Syft
 syft . -o cyclonedx-json > sbom.cdx.json
-
-# Using Trivy (see advisory below)
-trivy fs . --format cyclonedx --output sbom.cdx.json
 ```
 
 Note: We [no longer consider Trivy safe](/2026/03/26/trivy-compromise-hardening-sbomify-action/) following two successful supply chain attacks in March 2026 and have removed it from sbomify-action.

--- a/content/faq/how-do-i-generate-an-sbom.md
+++ b/content/faq/how-do-i-generate-an-sbom.md
@@ -1,8 +1,8 @@
 ---
 title: "How do I generate an SBOM?"
 description: "Step-by-step guide to generating your first SBOM using sbomify-action, open-source tools, and CI/CD integration."
-answer: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action init) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
-tldr: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action init) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
+answer: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action wizard) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
+tldr: "The easiest way is with sbomify-action, which generates, enriches, and uploads SBOMs from your lockfiles or Docker images in CI/CD. Run its interactive setup wizard (sbomify-action wizard) to get a working pipeline in minutes. You can also use standalone tools like Syft or cdxgen."
 weight: 60
 keywords: [generate SBOM, create SBOM, SBOM tools, SBOM generation, how to SBOM, sbomify-action]
 url: /faq/how-do-i-generate-an-sbom/
@@ -10,11 +10,14 @@ url: /faq/how-do-i-generate-an-sbom/
 
 ## Fastest path: the setup wizard
 
-If you are starting from scratch, run the interactive [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/) in your repository:
+If you are starting from scratch, run the interactive [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/) from the root of your repository. The Docker image bundles everything it needs:
 
 ```bash
-pip install sbomify-action
-sbomify-action init
+docker run --rm -it \
+  -v "$(pwd):/github/workspace" \
+  -w /github/workspace \
+  ghcr.io/sbomify/sbomify-action \
+  sbomify-action wizard
 ```
 
 The wizard scans your repo for lockfiles, signs you in to sbomify, creates your product and components, registers [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/), and writes a ready-to-commit `.github/workflows/sboms.yml`. Commit the file and your next push generates and uploads an SBOM.

--- a/content/faq/how-do-i-set-up-a-trust-center.md
+++ b/content/faq/how-do-i-set-up-a-trust-center.md
@@ -26,7 +26,7 @@ To set up your Trust Center:
 5. Set your **custom domain** (e.g. `trust.yourcompany.com`) and click **Save Domain**
 6. Configure a CNAME record with your DNS provider pointing to sbomify, then wait for the domain to validate
 
-Once enabled, your uploaded SBOMs and compliance documents are automatically published to your Trust Center. You can see a live example at [trust.sbomify.com](https://trust.sbomify.com/).
+Once enabled, your uploaded SBOMs and compliance documents are automatically published to your Trust Center. Public release pages also expose release-level [VEX](/faq/how-do-i-use-vex/) and [CBOM](/faq/what-is-a-cbom/) downloads next to the release SBOM. You can see a live example at [trust.sbomify.com](https://trust.sbomify.com/).
 
 ## Component visibility
 

--- a/content/faq/how-do-i-set-up-oidc-trusted-publishing.md
+++ b/content/faq/how-do-i-set-up-oidc-trusted-publishing.md
@@ -1,0 +1,56 @@
+---
+title: "How do I set up OIDC trusted publishing?"
+description: "OIDC trusted publishing lets GitHub Actions upload SBOMs to sbomify without any long-lived token secret, using short-lived OpenID Connect tokens instead."
+answer: "Add a trusted publisher binding to your component in the sbomify app (Component Settings, Trusted Publishers), then grant your GitHub Actions workflow 'permissions: id-token: write' and drop the TOKEN secret. sbomify-action detects the OIDC environment automatically, exchanges GitHub's OIDC token for a short-lived sbomify token, and uploads. No secrets to create, rotate, or leak."
+tldr: "Trusted publishing replaces long-lived API tokens with short-lived OpenID Connect tokens minted by GitHub for each workflow run. Bind your repository to a component once in the sbomify UI, add 'id-token: write' to your workflow, and uploads just work - no token secret anywhere."
+weight: 62
+keywords: [OIDC trusted publishing, tokenless SBOM upload, GitHub Actions OIDC, sbomify trusted publisher, keyless publishing, id-token write]
+url: /faq/how-do-i-set-up-oidc-trusted-publishing/
+---
+
+## What trusted publishing is
+
+Long-lived API tokens are a liability: they live in secret stores, they leak, and they need rotating (sbomify personal access tokens expire after 90 days by default for exactly this reason). Trusted publishing, the same model PyPI uses, removes them entirely for CI uploads.
+
+Instead of a stored secret, GitHub Actions mints a short-lived OpenID Connect (OIDC) token for each workflow run that cryptographically proves which repository and workflow is running. sbomify verifies that token and exchanges it for a sbomify access token that is valid for about 15 minutes and scoped to the one component the repository is bound to. When the run ends, there is nothing left to steal.
+
+## Setting it up
+
+### 1. Create the trusted publisher binding
+
+In the [sbomify app](https://app.sbomify.com), open your component's settings and add a **Trusted Publisher** with your GitHub organization and repository. Private repositories are supported. To defeat repository resurrection attacks, sbomify pins the immutable GitHub repository and owner IDs, not just the names.
+
+If you onboard with the [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/), this step happens automatically.
+
+### 2. Update your workflow
+
+Grant the OIDC permission and remove the `TOKEN` secret:
+
+```yaml
+permissions:
+  id-token: write
+
+steps:
+  - name: Upload SBOM
+    uses: sbomify/sbomify-action@master
+    env:
+      COMPONENT_ID: 'my-component-id'
+      LOCK_FILE: 'requirements.txt'
+      AUGMENT: true
+      ENRICH: true
+      UPLOAD: true
+```
+
+That is the whole setup. sbomify-action auto-detects the OIDC environment when no `TOKEN` is set. If both are present, `TOKEN` takes precedence. Self-hosted sbomify instances can override the token audience with the `oidc-audience` input (default `sbomify.com`).
+
+## Scope and limits
+
+- The exchanged token is scoped to the component bound to the repository. A compromised workflow cannot touch the rest of your workspace.
+- OIDC trusted publishing currently works in **GitHub Actions**. On GitLab CI, Bitbucket Pipelines, and other CI systems, keep using a token via the `TOKEN` environment variable.
+- Uploads, augmentation, and release tagging all work over the exchanged token.
+
+## Further reading
+
+- [How do I use the sbomify setup wizard?](/faq/how-do-i-use-the-sbomify-setup-wizard/) - registers trusted publishing for you
+- [How do I generate an SBOM?](/faq/how-do-i-generate-an-sbom/) - the generation pipeline the upload belongs to
+- [How do I sign an SBOM?](/faq/how-do-i-sign-an-sbom/) - complementary provenance for the SBOM itself

--- a/content/faq/how-do-i-sign-an-sbom.md
+++ b/content/faq/how-do-i-sign-an-sbom.md
@@ -36,22 +36,28 @@ The simplest way to sign an SBOM today is with GitHub's built-in attestation sup
 In your GitHub Actions workflow, generate the SBOM and then pass it to the attestation action:
 
 ```yaml
-- name: Generate SBOM
-  uses: sbomify/sbomify-action@master
-  env:
-    TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
-    COMPONENT_ID: 'your-component-id'
-    LOCK_FILE: 'requirements.txt'
-    AUGMENT: true
-    ENRICH: true
-    UPLOAD: true
-    OUTPUT_FILE: sbom.cdx.json
+permissions:
+  id-token: write
+  attestations: write
 
-- name: Attest SBOM
-  uses: actions/attest-build-provenance@v1
-  with:
-    subject-path: '${{ github.workspace }}/sbom.cdx.json'
+steps:
+  - name: Generate SBOM
+    uses: sbomify/sbomify-action@master
+    env:
+      COMPONENT_ID: 'your-component-id'
+      LOCK_FILE: 'requirements.txt'
+      AUGMENT: true
+      ENRICH: true
+      UPLOAD: true
+      OUTPUT_FILE: sbom.cdx.json
+
+  - name: Attest SBOM
+    uses: actions/attest-build-provenance@v1
+    with:
+      subject-path: '${{ github.workspace }}/sbom.cdx.json'
 ```
+
+The `id-token: write` permission also enables [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/), so the upload itself needs no token secret either.
 
 That is it. GitHub signs the SBOM using your workflow's identity, records the signature in a [Sigstore transparency log](/2024/08/12/what-is-sigstore/), and links it to the exact repository and workflow run that produced it.
 

--- a/content/faq/how-do-i-use-the-sbomify-setup-wizard.md
+++ b/content/faq/how-do-i-use-the-sbomify-setup-wizard.md
@@ -1,7 +1,7 @@
 ---
 title: "How do I use the sbomify setup wizard?"
-description: "The interactive setup wizard (sbomify-action init) scans your repository, creates your products and components, sets up OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow."
-answer: "Run 'pip install sbomify-action' followed by 'sbomify-action init' in your repository. The interactive wizard scans your repo for lockfiles, signs you in to sbomify, lets you pick or create the product and components, registers OIDC trusted publishing, and writes a ready-to-commit .github/workflows/sboms.yml. Commit the file and your next push generates and uploads an SBOM."
+description: "The interactive setup wizard (sbomify-action wizard) scans your repository, creates your products and components, sets up OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow."
+answer: "Run 'sbomify-action wizard' from the root of your repository using the Docker image, which bundles everything the wizard needs. The interactive wizard scans your repo for lockfiles, signs you in to sbomify, lets you pick or create the product and components, registers OIDC trusted publishing, and writes a ready-to-commit .github/workflows/sboms.yml. Commit the file and your next push generates and uploads an SBOM."
 tldr: "The setup wizard is the fastest way from zero to automated SBOMs. It is an interactive terminal UI that configures everything - products, components, OIDC trusted publishing, and the CI workflow file - so you never hand-write YAML or copy a token."
 weight: 61
 keywords: [sbomify setup wizard, sbomify-action init, SBOM onboarding, SBOM CI setup, generate SBOM quickly, sbomify getting started]
@@ -23,18 +23,23 @@ Commit the generated workflow file and your next push generates, enriches, and u
 
 ## Running it
 
+Run the wizard from the root of your repository with the Docker image. The image bundles every tool the wizard needs, so there is nothing else to install:
+
 ```bash
-pip install sbomify-action
-sbomify-action init
+docker run --rm -it \
+  -v "$(pwd):/github/workspace" \
+  -w /github/workspace \
+  ghcr.io/sbomify/sbomify-action \
+  sbomify-action wizard
 ```
 
-`sbomify-action wizard` is an alias for the same command. Useful flags:
+The `-it` flags are required because the wizard is interactive, and the volume mount is what lets it write the generated workflow back into your repo. If you prefer not to use Docker, you can also `pip install sbomify-action` and run `sbomify-action wizard` directly (`sbomify-action init` is a backwards-compatible alias). Useful flags:
 
-- `--dry-run` - walk through the wizard without creating anything
+- `--dry-run` - preview the full plan without making API changes or writing files
 - `--repo-root <path>` - point at a repository other than the current directory
-- `--output-dir <path>` - write the workflow file somewhere else
+- `--output-dir <path>` - where the workflow is written (must resolve to `.github/workflows`)
 
-The wizard is designed for interactive use and refuses to run inside CI. In CI, you run the workflow file the wizard produced.
+The wizard is designed for interactive use and refuses to run inside CI. It also will not overwrite a hand-authored `sboms.yml`; it only manages workflows it generated. In CI, you run the workflow file the wizard produced.
 
 ## When to configure things manually instead
 

--- a/content/faq/how-do-i-use-the-sbomify-setup-wizard.md
+++ b/content/faq/how-do-i-use-the-sbomify-setup-wizard.md
@@ -1,0 +1,47 @@
+---
+title: "How do I use the sbomify setup wizard?"
+description: "The interactive setup wizard (sbomify-action init) scans your repository, creates your products and components, sets up OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow."
+answer: "Run 'pip install sbomify-action' followed by 'sbomify-action init' in your repository. The interactive wizard scans your repo for lockfiles, signs you in to sbomify, lets you pick or create the product and components, registers OIDC trusted publishing, and writes a ready-to-commit .github/workflows/sboms.yml. Commit the file and your next push generates and uploads an SBOM."
+tldr: "The setup wizard is the fastest way from zero to automated SBOMs. It is an interactive terminal UI that configures everything - products, components, OIDC trusted publishing, and the CI workflow file - so you never hand-write YAML or copy a token."
+weight: 61
+keywords: [sbomify setup wizard, sbomify-action init, SBOM onboarding, SBOM CI setup, generate SBOM quickly, sbomify getting started]
+url: /faq/how-do-i-use-the-sbomify-setup-wizard/
+---
+
+## What the wizard does
+
+The setup wizard is an interactive terminal UI built into [sbomify-action](https://github.com/sbomify/sbomify-action). It is the recommended way to onboard a repository, because it automates every step that used to be manual:
+
+1. **Scans your repository** for lockfiles across all supported ecosystems (Python, JavaScript, Java, Go, Rust, and more) and proposes one component per lockfile it finds.
+2. **Signs you in to sbomify** so it can work against your workspace.
+3. **Picks or creates the product and components** your SBOMs will belong to.
+4. **Lets you choose your options**: release strategy, SBOM format, enrichment, and attestation.
+5. **Registers OIDC trusted publishing** for each component, so your workflow needs no long-lived token secret. See [How do I set up OIDC trusted publishing?](/faq/how-do-i-set-up-oidc-trusted-publishing/) for how that works.
+6. **Writes a ready-to-commit `.github/workflows/sboms.yml`** (and an optional `sbomify.json` for business metadata), pinned to the latest sbomify-action release.
+
+Commit the generated workflow file and your next push generates, enriches, and uploads an SBOM.
+
+## Running it
+
+```bash
+pip install sbomify-action
+sbomify-action init
+```
+
+`sbomify-action wizard` is an alias for the same command. Useful flags:
+
+- `--dry-run` - walk through the wizard without creating anything
+- `--repo-root <path>` - point at a repository other than the current directory
+- `--output-dir <path>` - write the workflow file somewhere else
+
+The wizard is designed for interactive use and refuses to run inside CI. In CI, you run the workflow file the wizard produced.
+
+## When to configure things manually instead
+
+The wizard targets GitHub Actions. If you use GitLab CI, Bitbucket Pipelines, or another CI system, use the Docker image or pip package directly - see our [integrations page](/features/integrations/) and [CI/CD guide](/guides/ci-cd/) for ready-to-use templates. Everything the wizard configures can also be set up by hand: components in the [sbomify app](https://app.sbomify.com), workflow YAML from the templates.
+
+## Further reading
+
+- [How do I generate an SBOM?](/faq/how-do-i-generate-an-sbom/) - the broader generation options
+- [How do I set up OIDC trusted publishing?](/faq/how-do-i-set-up-oidc-trusted-publishing/) - tokenless uploads explained
+- [Zero to Hero](/zero-to-hero/) - the full onboarding walkthrough

--- a/content/faq/how-do-i-use-vex.md
+++ b/content/faq/how-do-i-use-vex.md
@@ -1,10 +1,10 @@
 ---
 title: "How do I use VEX with sbomify?"
-description: "Learn how Vulnerability Exploitability eXchange (VEX) lets you communicate which vulnerabilities actually affect your product, and how to upload and distribute VEX documents through sbomify."
-answer: "A VEX document tells consumers which vulnerabilities in your SBOM are actually exploitable in your product and which are not. You generate a CycloneDX VEX file alongside your SBOM, upload it to the same component in sbomify, and your customers can download both from your Trust Center to make accurate risk decisions without re-running the scanner."
-tldr: "VEX is the companion to your SBOM that says \"this CVE is in our dependency tree but it does not actually affect our product, here is why.\" sbomify stores VEX documents per component the same way it stores SBOMs, so consumers see both side-by-side in the Trust Center."
+description: "Learn how Vulnerability Exploitability eXchange (VEX) lets you communicate which vulnerabilities actually affect your product, and how to upload, triage, and distribute VEX documents through sbomify."
+answer: "A VEX document tells consumers which vulnerabilities in your SBOM are actually exploitable in your product and which are not. sbomify ingests CycloneDX VEX, OpenVEX, and CSAF 2.0 VEX, applies your statements to OSV and Dependency Track findings so noise is suppressed, and publishes the VEX alongside your SBOMs in your Trust Center. You can also triage vulnerabilities directly in sbomify and generate a VEX from your decisions."
+tldr: "VEX is the companion to your SBOM that says \"this CVE is in our dependency tree but it does not actually affect our product, here is why.\" sbomify accepts VEX in CycloneDX, OpenVEX, and CSAF 2.0 formats, suppresses VEX'd findings in your vulnerability results, flags CISA KEV entries, and shares VEX next to SBOMs in the Trust Center."
 weight: 67
-keywords: [VEX, CycloneDX VEX, vulnerability exploitability, SBOM VEX, CSAF VEX, vulnerability triage, false positive, CRA VEX]
+keywords: [VEX, CycloneDX VEX, OpenVEX, CSAF VEX, vulnerability exploitability, SBOM VEX, vulnerability triage, CISA KEV, false positive, CRA VEX]
 url: /faq/how-do-i-use-vex/
 ---
 
@@ -27,7 +27,7 @@ Telling that signal-from-noise story by hand - in spreadsheets, GitHub issues, t
 
 ## What a VEX document looks like
 
-VEX is most commonly produced in **CycloneDX VEX format** (a CycloneDX BOM with `vulnerabilities[]` populated) or **CSAF VEX** (an OASIS standard JSON document). sbomify stores CycloneDX VEX today; CSAF can be uploaded as a regulatory document via the Document feature.
+sbomify ingests VEX in three formats, with automatic format detection: **CycloneDX VEX** (a CycloneDX BOM with `vulnerabilities[]` populated, JSON or XML), **OpenVEX** (the lightweight format used by vexctl and Chainguard), and **CSAF 2.0 VEX** (the OASIS standard used heavily by OS vendors like Red Hat and Cisco). See [What VEX formats does sbomify support?](/faq/what-vex-formats-does-sbomify-support/) for the format-by-format details.
 
 A minimal CycloneDX VEX statement looks like this:
 
@@ -79,11 +79,11 @@ sbomify's CRA Compliance plugin checks for the SBOM/VEX split and flags SBOMs th
 
 ## Uploading VEX to sbomify
 
-sbomify treats a VEX document as a separate artifact attached to the same component as its SBOM. There is no separate "VEX component" - the relationship is artifact-to-component, the same as SBOMs.
+sbomify treats a VEX document as a separate artifact attached to the same component as its SBOM. There is no separate "VEX component" - the relationship is artifact-to-component, the same as SBOMs. You can upload VEX in any supported format through the upload panel on the component page, via the API, or from CI.
 
 ### Via the API
 
-Use the same artifact endpoint as a regular SBOM upload, with `bom_type=vex`:
+For CycloneDX VEX, use the same artifact endpoint as a regular SBOM upload, with `bom_type=vex`:
 
 ```bash
 curl -X POST "https://app.sbomify.com/api/v1/sboms/artifact/cyclonedx/<component_id>?bom_type=vex" \
@@ -92,46 +92,50 @@ curl -X POST "https://app.sbomify.com/api/v1/sboms/artifact/cyclonedx/<component
   --data-binary "@my-product.vex.json"
 ```
 
-A successful upload returns the new artifact's id. The component detail page now lists the VEX alongside the SBOM, and the Trust Center exposes it under the same component.
+OpenVEX and CSAF 2.0 VEX documents go to the format-agnostic VEX endpoint, where the format is detected automatically:
 
-VEX uploads are CycloneDX-only today - the unified BOM-as-VEX model is a CycloneDX feature. SPDX users who need to publish exploitability data should use [CSAF VEX](https://oasis-open.github.io/csaf-documentation/) and upload it via sbomify's [compliance documents](/faq/how-do-i-upload-compliance-documents/) feature instead.
+```bash
+curl -X POST "https://app.sbomify.com/api/v1/sboms/artifact/vex/<component_id>" \
+  -H "Authorization: Bearer ${SBOMIFY_TOKEN}" \
+  -H "Content-Type: application/json" \
+  --data-binary "@my-product.openvex.json"
+```
+
+A successful upload returns the new artifact's id. The component detail page now lists the VEX alongside the SBOM, and the Trust Center exposes it under the same component.
 
 ### Via CI
 
-In your existing sbomify-action workflow, generate the VEX after the SBOM and post it to the same component:
+In your existing [sbomify-action](https://github.com/sbomify/sbomify-action) workflow, upload a pre-authored VEX with `BOM_TYPE: vex`. The document is uploaded verbatim, byte for byte, with format detection on the server side. With [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/) you do not even need a token secret:
 
 ```yaml
-- name: Generate SBOM
-  uses: sbomify/sbomify-action@master
-  env:
-    TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
-    COMPONENT_ID: ${{ vars.SBOMIFY_COMPONENT_ID }}
-    LOCK_FILE: 'requirements.txt'
-    OUTPUT_FILE: sbom.cdx.json
-    UPLOAD: true
+permissions:
+  id-token: write
 
-- name: Generate VEX
-  run: ./scripts/produce-vex.sh sbom.cdx.json > vex.cdx.json
+steps:
+  - name: Generate VEX
+    run: ./scripts/produce-vex.sh sbom.cdx.json > vex.cdx.json
 
-- name: Upload VEX to sbomify
-  run: |
-    curl -fsS -X POST \
-      "https://app.sbomify.com/api/v1/sboms/artifact/cyclonedx/${{ vars.SBOMIFY_COMPONENT_ID }}?bom_type=vex" \
-      -H "Authorization: Bearer ${{ secrets.SBOMIFY_TOKEN }}" \
-      -H "Content-Type: application/json" \
-      --data-binary "@vex.cdx.json"
+  - name: Upload VEX to sbomify
+    uses: sbomify/sbomify-action@master
+    env:
+      COMPONENT_ID: ${{ vars.SBOMIFY_COMPONENT_ID }}
+      SBOM_FILE: vex.cdx.json
+      BOM_TYPE: vex
+      UPLOAD: true
 ```
 
-The shape of `produce-vex.sh` is up to you - tools like [Dependency-Track's VEX export](https://docs.dependencytrack.org/usage/vex/), [vexctl](https://github.com/openvex/vexctl), or your own triage workflow can produce the input.
+If your CI platform does not support OIDC, set `TOKEN: ${{ secrets.SBOMIFY_TOKEN }}` instead. The shape of `produce-vex.sh` is up to you - tools like [Dependency-Track's VEX export](https://docs.dependencytrack.org/usage/vex/), [vexctl](https://github.com/openvex/vexctl), or your own triage workflow can produce the input.
 
-## Producing VEX statements without a manual triage
+## Triaging vulnerabilities in sbomify
 
-VEX statements should be produced by the people closest to the code, but the wiring does not have to be artisanal. Two practical patterns:
+You do not have to author VEX by hand or in an external tool. sbomify has an in-app triage workflow:
 
-- **Triage-then-export.** Use Dependency-Track or a similar vulnerability database as the system of record. Mark findings as `Not Affected`, `False Positive`, or `Exploitable` with justification through the UI, then export the analysis as CycloneDX VEX. The exported file becomes the artifact you upload to sbomify on every release.
-- **Source-controlled VEX.** Keep a `vex/` directory in the same repo that produces the SBOM, with one CycloneDX VEX statement per CVE you have triaged. The CI pipeline merges the per-CVE files into a single VEX document and uploads it alongside the SBOM. Pull requests on `vex/` carry the audit trail.
+- **In-app triage.** Review scanner findings on the vulnerability dashboard, record `not_affected` decisions with justifications, apply bulk decisions across CVEs, and preview the effect with a dry run before committing.
+- **CISA KEV flags.** Findings that appear in the CISA Known Exploited Vulnerabilities catalog are flagged so you triage the vulnerabilities that attackers actually use first.
+- **Self-VEX generation.** sbomify generates a CycloneDX VEX from your triage decisions, complete with CISA tracking fields (serial number and statement timestamps), so your published VEX always matches your ledger.
+- **Dependency Track sync.** If Dependency Track is your triage system of record, sbomify syncs your DT analysis decisions in as VEX and pins them to the matching releases.
 
-Either way, the result is the same: when a customer downloads your SBOM, the VEX is right next to it, machine-readable, and dated.
+Alternatively, keep a source-controlled `vex/` directory in the same repo that produces the SBOM, merge the per-CVE statements in CI, and upload the result alongside the SBOM. Pull requests on `vex/` carry the audit trail.
 
 ## Signing your VEX
 
@@ -139,21 +143,20 @@ A VEX is a security-relevant claim about your product. Sign it with the same mac
 
 ## What sbomify does with VEX
 
-Today, sbomify stores and distributes VEX:
-
-- **Per-component listing.** The component detail page shows VEX artifacts alongside SBOMs.
-- **Trust Center exposure.** Customers downloading from your Trust Center see and can fetch the VEX with the same access controls as the SBOM.
+- **Scanner suppression.** Findings covered by a `not_affected` VEX statement are suppressed in your OSV and Dependency Track results, so the dashboard shows your triaged exposure instead of raw scanner noise. Uploading a new VEX re-applies it to existing scans automatically.
+- **Per-component listing.** The component detail page shows VEX artifacts alongside SBOMs, with distinct badges.
+- **Release-level VEX.** Each release exposes a merged VEX download, on both the internal release page and the public Trust Center release page, next to the release SBOM.
+- **Trust Center exposure.** Customers downloading from your Trust Center see and can fetch the VEX with the same access controls as the SBOM, and the release vulnerability posture card reflects your VEX-applied status.
 - **Audit trail.** Every VEX upload is logged the same way as an SBOM upload, with content hash, timestamp, and uploader identity.
-
-VEX-aware filtering of the OSV and Dependency-Track scanner results - automatically suppressing `not_affected` findings on the SBOM detail page - is on the roadmap. Until that lands, sbomify is the durable, audit-friendly storage and distribution layer for your VEX, and the scanner UIs continue to show the raw findings.
 
 ## Further reading
 
+- [What VEX formats does sbomify support?](/faq/what-vex-formats-does-sbomify-support/) - CycloneDX VEX, OpenVEX, and CSAF 2.0 in detail
 - [EU Cyber Resilience Act compliance guide](/compliance/eu-cra/) - the regulatory framing for SBOM/VEX separation
 - [What is the EU Cyber Resilience Act?](/faq/what-is-the-eu-cyber-resilience-act/) - the higher-level FAQ
 - [How do I sign an SBOM?](/faq/how-do-i-sign-an-sbom/) - sign your VEX the same way
 - [How do I enable vulnerability scanning?](/faq/how-do-i-enable-vulnerability-scanning/) - the scanner output your VEX is responsive to
 - [Schema crosswalk](/compliance/schema-crosswalk/) - how vulnerability data maps across CycloneDX, SPDX, CSAF, and VEX
 - [CycloneDX VEX use case](https://cyclonedx.org/use-cases/#vulnerability-exploitability) - the upstream spec
-- [OpenVEX](https://github.com/openvex/spec) - a lightweight VEX format that converts to CycloneDX
+- [OpenVEX](https://github.com/openvex/spec) - a lightweight VEX format, natively supported by sbomify
 - [CSAF VEX](https://oasis-open.github.io/csaf-documentation/) - the OASIS standard, used heavily in the OS-vendor ecosystem

--- a/content/faq/is-sbomify-free.md
+++ b/content/faq/is-sbomify-free.md
@@ -28,6 +28,10 @@ The Business tier is built for mid-size teams that need:
 
 - Private SBOM repositories
 - Team collaboration features
+- Custom trust center on your own domain
+- [Transparency Exchange API (TEA)](/faq/how-do-i-enable-tea-in-sbomify/)
+- [CRA Compliance Wizard](/faq/how-do-i-use-cra-compliance/)
+- [Dependency Track integration](/faq/how-do-i-enable-vulnerability-scanning/) and daily vulnerability re-scans
 - Compliance reporting
 - Priority support
 

--- a/content/faq/what-is-a-cbom.md
+++ b/content/faq/what-is-a-cbom.md
@@ -1,0 +1,42 @@
+---
+title: "What is a CBOM and how does sbomify support it?"
+description: "A Cryptography Bill of Materials (CBOM) inventories the cryptographic assets in your software. sbomify auto-detects CBOMs, builds a crypto inventory, and assesses post-quantum readiness."
+answer: "A CBOM (Cryptography Bill of Materials) is a CycloneDX BOM that inventories cryptographic assets: algorithms, keys, certificates, and protocols. sbomify auto-detects CBOM content on upload, renders a crypto-asset inventory, runs a post-quantum cryptography (PQC) readiness assessment against NIST guidance, and publishes CBOMs on your public release pages next to your SBOMs."
+tldr: "A CBOM is the cryptographic sibling of an SBOM: it lists the algorithms, keys, certificates, and protocols your software uses. sbomify ingests and auto-classifies CBOMs, shows a crypto inventory with a post-quantum readiness view, and shares them through your Trust Center."
+weight: 68
+keywords: [CBOM, Cryptography Bill of Materials, crypto inventory, post-quantum cryptography, PQC readiness, quantum-safe, CycloneDX CBOM]
+url: /faq/what-is-a-cbom/
+---
+
+## What a CBOM is
+
+A **Cryptography Bill of Materials (CBOM)** is a [CycloneDX](https://cyclonedx.org/capabilities/cbom/) BOM whose components include cryptographic assets: the algorithms, keys, certificates, protocols, and crypto libraries your software uses. Where an SBOM answers "what packages are in this product," a CBOM answers "what cryptography does this product depend on."
+
+That question is becoming urgent. Migrating to post-quantum cryptography starts with knowing where the quantum-vulnerable algorithms (RSA, ECDSA, classic Diffie-Hellman) live in your stack, and regulators are moving in the same direction: crypto agility features in NIST's post-quantum guidance and in EU CRA discussions alike. You cannot migrate what you have not inventoried.
+
+## What sbomify does with CBOMs
+
+- **Auto-detection.** Upload a CycloneDX document containing cryptographic assets and sbomify automatically classifies it as a CBOM, no special flag needed. You can also be explicit with `BOM_TYPE: cbom` in [sbomify-action](https://github.com/sbomify/sbomify-action), which uploads the document verbatim.
+- **Crypto-asset inventory.** The document detail page renders an inventory of the cryptographic assets found: algorithms, key sizes, certificates, and protocols.
+- **Post-quantum readiness.** The PQC readiness assessment plugin classifies each asset against NIST guidance and gives your component a post-quantum posture view, so you can see at a glance which algorithms are quantum-vulnerable and where.
+- **Trust Center distribution.** CBOMs appear on your public release pages next to SBOMs and VEX, with the same access controls, and are exposed through the [Transparency Exchange API](/faq/how-do-i-enable-tea-in-sbomify/) as a supported artifact type.
+
+## How do I generate a CBOM?
+
+CBOM generation tools are still an emerging space. [cbomkit](https://github.com/PQCA/cbomkit) and IBM's CBOM tooling can scan source code for cryptographic usage, and CycloneDX 1.6+ has first-class support for cryptographic asset types. However you produce it, sbomify handles storage, classification, analysis, and distribution:
+
+```yaml
+- name: Upload CBOM
+  uses: sbomify/sbomify-action@master
+  env:
+    COMPONENT_ID: 'my-component-id'
+    SBOM_FILE: 'my-product.cbom.json'
+    BOM_TYPE: cbom
+    UPLOAD: true
+```
+
+## Further reading
+
+- [What SBOM formats does sbomify support?](/faq/what-sbom-formats-does-sbomify-support/) - formats and BOM types overview
+- [How do I enable TEA in sbomify?](/faq/how-do-i-enable-tea-in-sbomify/) - programmatic artifact discovery, CBOMs included
+- [sbomify goes quantum-ready](/2026/07/07/announcing-sbomify-v26-7-0-the-one-that-gets-quantum-ready/) - the release announcement with more background

--- a/content/faq/what-is-an-sbom.md
+++ b/content/faq/what-is-an-sbom.md
@@ -21,7 +21,7 @@ Modern software is built from hundreds or thousands of open-source and third-par
 SBOMs help you:
 
 - **Identify vulnerabilities** - Know immediately if a vulnerable component is in your software
-- **Meet compliance requirements** - Regulations like the [EU Cyber Resilience Act](/compliance/eu-cra/) and [NTIA minimum elements](/compliance/ntia/) now require SBOMs
+- **Meet compliance requirements** - Regulations like the [EU Cyber Resilience Act](/compliance/eu-cra/) and [NTIA minimum elements](/compliance/ntia-minimum-elements/) now require SBOMs
 - **Build customer trust** - Share your software composition transparently via a [Trust Center](https://trust.sbomify.com/)
 - **Manage license risk** - Understand which open-source licenses apply to your codebase
 

--- a/content/faq/what-sbom-formats-does-sbomify-support.md
+++ b/content/faq/what-sbom-formats-does-sbomify-support.md
@@ -1,8 +1,8 @@
 ---
 title: "What SBOM formats does sbomify support?"
-description: "sbomify supports CycloneDX and SPDX SBOM formats in JSON, with automatic validation and schema compliance checking."
-answer: "sbomify supports both CycloneDX and SPDX - the two industry-standard SBOM formats - in JSON representation, with automatic validation against official schemas."
-tldr: "sbomify supports both CycloneDX and SPDX - the two industry-standard SBOM formats - in JSON representation, with automatic validation against official schemas."
+description: "sbomify supports CycloneDX 1.3-1.7 and SPDX 2.2, 2.3, and 3.0.1 SBOM formats in JSON, with automatic validation and schema compliance checking."
+answer: "sbomify supports both CycloneDX and SPDX - the two industry-standard SBOM formats. CycloneDX 1.3 through 1.7 and SPDX 2.2, 2.3, and 3.0.1 are accepted in JSON representation, with automatic validation against official schemas. Beyond SBOMs, sbomify also accepts VEX documents (CycloneDX VEX, OpenVEX, CSAF 2.0) and CBOMs."
+tldr: "sbomify supports both CycloneDX (1.3 through 1.7) and SPDX (2.2, 2.3, 3.0.1) - the two industry-standard SBOM formats - in JSON representation, with automatic validation against official schemas."
 weight: 30
 keywords: [SBOM formats, CycloneDX, SPDX, sbomify formats, SBOM standard]
 url: /faq/what-sbom-formats-does-sbomify-support/
@@ -16,7 +16,7 @@ sbomify supports the two major SBOM standards:
 
 [CycloneDX](https://cyclonedx.org/) is an OWASP project designed specifically for security use cases. It is lightweight, easy to generate, and widely supported by tooling.
 
-- **Versions supported:** CycloneDX 1.6, 1.7
+- **Versions supported:** CycloneDX 1.3 through 1.7
 - **Representations:** JSON
 - **Strengths:** Security-focused, supports VEX (Vulnerability Exploitability eXchange), extensive tooling ecosystem
 
@@ -24,13 +24,17 @@ sbomify supports the two major SBOM standards:
 
 [SPDX](https://spdx.dev/) (Software Package Data Exchange) is an ISO/IEC international standard (5962:2021) with deep roots in license compliance.
 
-- **Versions supported:** SPDX 2.3, 3.0
-- **Representations:** JSON
+- **Versions supported:** SPDX 2.2, 2.3, 3.0.1
+- **Representations:** JSON (JSON-LD for 3.0.1)
 - **Strengths:** ISO standard, strong license compliance support, widely used in automotive and enterprise
 
 ## Automatic validation
 
 When you upload an SBOM to sbomify, it is automatically validated against the official schema for its format and version. This helps catch malformed documents before they enter your pipeline.
+
+## VEX and other BOM types
+
+SBOMs are not the only artifacts sbomify accepts. VEX documents are ingested natively in **CycloneDX VEX (JSON and XML), OpenVEX, and CSAF 2.0 VEX** formats, with automatic format detection - see [What VEX formats does sbomify support?](/faq/what-vex-formats-does-sbomify-support/). Cryptography Bills of Materials ([CBOMs](/faq/what-is-a-cbom/)) are detected and classified automatically on upload, and CI pipelines can upload VEX, CBOM, and HBOM artifacts verbatim with the sbomify-action `BOM_TYPE` setting.
 
 ## Which format should I choose?
 
@@ -45,4 +49,4 @@ Most SBOM generation tools support both formats. See our [language guides](/guid
 
 We strongly recommend against converting between CycloneDX and SPDX. The two formats have different data models, and conversion is inherently lossy - fields, relationships, and metadata will be dropped or misrepresented in the process. The resulting SBOM may look valid but will be incomplete or inaccurate.
 
-Instead, generate your SBOMs natively in the format you need. Some tools like Syft and ~~Trivy~~ ([compromised March 2026](/2026/03/26/trivy-compromise-hardening-sbomify-action/)) support both formats, but many generators only output one. Check our [Resources page](/resources/) for a list of SBOM generation tools and their supported formats.
+Instead, generate your SBOMs natively in the format you need. Tools like Syft support both formats, but many generators only output one. Check our [Resources page](/resources/) for a list of SBOM generation tools and their supported formats.

--- a/content/faq/what-vex-formats-does-sbomify-support.md
+++ b/content/faq/what-vex-formats-does-sbomify-support.md
@@ -1,0 +1,39 @@
+---
+title: "What VEX formats does sbomify support?"
+description: "sbomify natively ingests VEX documents in CycloneDX VEX (JSON and XML), OpenVEX, and CSAF 2.0 VEX formats, with automatic format detection."
+answer: "sbomify ingests VEX in three formats: CycloneDX VEX (JSON and XML), OpenVEX (the format used by vexctl and Chainguard), and CSAF 2.0 VEX (the OASIS standard used by vendors like Red Hat and Cisco). The format is detected automatically on upload, and statements are applied to your OSV and Dependency Track findings."
+tldr: "CycloneDX VEX (JSON and XML), OpenVEX, and CSAF 2.0 VEX are all natively supported, with automatic format detection. Upload through the component page, the API, or CI with BOM_TYPE: vex."
+weight: 66
+keywords: [VEX formats, CycloneDX VEX, OpenVEX, CSAF VEX, CSAF 2.0, VEX support, vexctl, upload VEX]
+url: /faq/what-vex-formats-does-sbomify-support/
+---
+
+## Supported formats
+
+sbomify ingests VEX documents in the three formats that matter in practice, and detects which one you uploaded automatically:
+
+| Format            | Typical producers                                                    | Notes                                                                |
+| ----------------- | -------------------------------------------------------------------- | -------------------------------------------------------------------- |
+| **CycloneDX VEX** | Dependency-Track exports, CycloneDX tooling, sbomify's own triage    | JSON and XML accepted; the richest format, with five analysis states |
+| **OpenVEX**       | [vexctl](https://github.com/openvex/vexctl), Chainguard tooling      | Lightweight JSON-LD format from the OpenVEX project                  |
+| **CSAF 2.0 VEX**  | OS and hardware vendor advisories (Red Hat, Cisco, SUSE, and others) | The OASIS standard for machine-readable security advisories          |
+
+One nuance worth knowing: `not_affected` statements suppress findings from all three formats, while the `false_positive` analysis state is specific to CycloneDX.
+
+## How to upload
+
+- **In the app.** Use the upload panel on the component page. VEX artifacts are listed next to SBOMs with their own badge.
+- **Via the API.** CycloneDX VEX goes to the CycloneDX artifact endpoint with `bom_type=vex`; OpenVEX and CSAF documents go to the format-agnostic `/api/v1/sboms/artifact/vex/` endpoint, which detects the format for you.
+- **From CI.** Set `BOM_TYPE: vex` in your [sbomify-action](https://github.com/sbomify/sbomify-action) step. The document is uploaded verbatim, byte for byte, with no modification.
+
+## What happens after upload
+
+Your VEX statements are applied to existing OSV and Dependency Track scan results, suppressing findings you have marked as not affected. Each release exposes a merged VEX download on both the internal release page and the public Trust Center release page.
+
+For the full workflow, including in-app triage, CISA KEV flags, and generating VEX from your own triage decisions, see [How do I use VEX with sbomify?](/faq/how-do-i-use-vex/).
+
+## Further reading
+
+- [How do I use VEX with sbomify?](/faq/how-do-i-use-vex/) - the complete VEX workflow
+- [What SBOM formats does sbomify support?](/faq/what-sbom-formats-does-sbomify-support/) - the SBOM side of the house
+- [Schema crosswalk](/compliance/schema-crosswalk/) - how vulnerability data maps across CycloneDX, SPDX, CSAF, and VEX

--- a/content/faq/why-do-i-need-an-sbom.md
+++ b/content/faq/why-do-i-need-an-sbom.md
@@ -23,7 +23,7 @@ When a new CVE drops, an SBOM lets you search your entire software portfolio in 
 SBOMs are increasingly required by law and industry standards:
 
 - **[EU Cyber Resilience Act (CRA)](/compliance/eu-cra/)** - Requires SBOMs for all products with digital elements sold in the EU
-- **[NTIA Minimum Elements](/compliance/ntia/)** - US government baseline for SBOM content
+- **[NTIA Minimum Elements](/compliance/ntia-minimum-elements/)** - US government baseline for SBOM content
 - **[NIST 800-171](/compliance/nist-800-171/)** - Supply chain risk management requirements
 - **[FDA guidance](/compliance/fda/)** - Medical device manufacturers must submit SBOMs
 - **[PCI DSS 4.0](/compliance/pci-dss/)** - Payment industry now references software composition analysis

--- a/content/features/_index.md
+++ b/content/features/_index.md
@@ -9,7 +9,7 @@ description: "Explore sbomify's comprehensive feature set for managing, sharing,
 
 ### Generate, Collaborate, and Analyze
 
-Streamline your SBOM workflow from creation to analysis. Our comprehensive toolset helps you generate accurate SBOMs, collaborate with your team, and gain insights from your software supply chain data. [Learn more about the SBOM lifecycle →](/features/generate-collaborate-analyze)
+Streamline your SBOM workflow from creation to analysis. Our comprehensive toolset helps you generate accurate SBOMs, collaborate with your team, and gain insights from your software supply chain data. Triage vulnerabilities with [multi-format VEX](/faq/how-do-i-use-vex/) (CycloneDX, OpenVEX, CSAF), and inventory your cryptography with [CBOMs](/faq/what-is-a-cbom/) including post-quantum readiness scoring. [Learn more about the SBOM lifecycle →](/features/generate-collaborate-analyze)
 
 ### Trust Center
 

--- a/content/features/integrations.html
+++ b/content/features/integrations.html
@@ -20,11 +20,14 @@ description: "Seamlessly integrate SBOM generation, analysis, and enrichment int
         <a href="/faq/how-do-i-use-the-sbomify-setup-wizard/" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap">Read the FAQ →</a>
       </div>
       <p class="text-gray-300 mb-6">
-        The fastest way to get started. Run <code class="text-[#8A7DFF]">sbomify-action init</code> in your repository and the wizard scans your lockfiles, creates your products and components, registers OIDC trusted publishing, and writes a ready-to-commit <code class="text-[#8A7DFF]">.github/workflows/sboms.yml</code>. No tokens to copy, no YAML to hand-write.
+        The fastest way to get started. Run the wizard from the root of your repository and it scans your lockfiles, creates your products and components, registers OIDC trusted publishing, and writes a ready-to-commit <code class="text-[#8A7DFF]">.github/workflows/sboms.yml</code>. No tokens to copy, no YAML to hand-write.
       </p>
       <div class="bg-[#141035] rounded-lg p-4 overflow-x-auto text-sm text-gray-300 font-mono border border-[#37306B]">
-<pre><code>pip install sbomify-action
-sbomify-action init</code></pre>
+<pre><code>docker run --rm -it \
+  -v "$(pwd):/github/workspace" \
+  -w /github/workspace \
+  ghcr.io/sbomify/sbomify-action \
+  sbomify-action wizard</code></pre>
       </div>
     </div>
 

--- a/content/features/integrations.html
+++ b/content/features/integrations.html
@@ -13,6 +13,21 @@ description: "Seamlessly integrate SBOM generation, analysis, and enrichment int
       <p class="text-lg text-secondaryText">Generate SBOMs automatically in your pipelines. We support all major CI/CD providers.</p>
     </div>
 
+    <!-- Setup Wizard -->
+    <div class="bg-[#201B4C] rounded-2xl p-6 md:p-8 border border-[#8A7DFF] shadow-sm mb-8" id="wizard">
+      <div class="flex flex-col md:flex-row md:items-center justify-between mb-4 gap-4">
+        <span class="text-2xl font-bold text-white">New: Interactive Setup Wizard</span>
+        <a href="/faq/how-do-i-use-the-sbomify-setup-wizard/" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap">Read the FAQ →</a>
+      </div>
+      <p class="text-gray-300 mb-6">
+        The fastest way to get started. Run <code class="text-[#8A7DFF]">sbomify-action init</code> in your repository and the wizard scans your lockfiles, creates your products and components, registers OIDC trusted publishing, and writes a ready-to-commit <code class="text-[#8A7DFF]">.github/workflows/sboms.yml</code>. No tokens to copy, no YAML to hand-write.
+      </p>
+      <div class="bg-[#141035] rounded-lg p-4 overflow-x-auto text-sm text-gray-300 font-mono border border-[#37306B]">
+<pre><code>pip install sbomify-action
+sbomify-action init</code></pre>
+      </div>
+    </div>
+
     <div class="grid grid-cols-1 md:grid-cols-2 gap-8">
       <!-- GitHub -->
       <div class="bg-[#201B4C] rounded-2xl p-6 md:p-8 border border-[#37306B] shadow-sm hover:border-[#8A7DFF] transition-all" id="github">
@@ -24,22 +39,26 @@ description: "Seamlessly integrate SBOM generation, analysis, and enrichment int
           <a href="https://github.com/marketplace/actions/sbomify" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap" target="_blank">View on Marketplace →</a>
         </div>
         <p class="text-gray-300 mb-6">
-          GitHub is at the core of many organizations. Our <a href="https://github.com/sbomify/sbomify-action" class="text-[#8A7DFF] hover:text-white transition-colors">GitHub Action</a> makes integration straightforward.
+          GitHub is at the core of many organizations. Our <a href="https://github.com/sbomify/sbomify-action" class="text-[#8A7DFF] hover:text-white transition-colors">GitHub Action</a> supports <a href="/faq/how-do-i-set-up-oidc-trusted-publishing/" class="text-[#8A7DFF] hover:text-white transition-colors">OIDC trusted publishing</a>, so no long-lived token secret is needed.
         </p>
         <div class="bg-[#141035] rounded-lg p-4 overflow-x-auto text-sm text-gray-300 font-mono border border-[#37306B]">
 
-<pre><code>- name: Upload SBOM
-  uses: sbomify/sbomify-action@master
-  env:
-    TOKEN: ${{ secrets.SBOMIFY_TOKEN }}
-    COMPONENT_ID: 'my-component-id'
-    LOCK_FILE: 'requirements.txt'
-    COMPONENT_NAME: 'my-awesome-app'
-    COMPONENT_VERSION: ${{ github.ref_name }}
-    AUGMENT: true
-    ENRICH: true</code></pre>
+<pre><code>permissions:
+  id-token: write  # OIDC trusted publishing, no token needed
+
+steps:
+  - name: Upload SBOM
+    uses: sbomify/sbomify-action@master
+    env:
+      COMPONENT_ID: 'my-component-id'
+      LOCK_FILE: 'requirements.txt'
+      COMPONENT_NAME: 'my-awesome-app'
+      COMPONENT_VERSION: ${{ github.ref_name }}
+      AUGMENT: true
+      ENRICH: true</code></pre>
 
         </div>
+        <p class="text-sm text-gray-400 mt-4">Prefer token auth, or using another CI system? Set <code class="text-[#8A7DFF]">TOKEN: ${SBOMIFY_TOKEN}</code> instead.</p>
       </div>
 
       <!-- GitLab -->
@@ -49,19 +68,18 @@ description: "Seamlessly integrate SBOM generation, analysis, and enrichment int
           <a href="https://github.com/sbomify/sbomify-action" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap" target="_blank">View on GitHub →</a>
         </div>
         <p class="text-gray-300 mb-6">
-          Use our <a href="https://hub.docker.com/r/sbomifyhub/sbomify-action" class="text-[#8A7DFF] hover:text-white transition-colors">Docker image</a> directly in GitLab CI with built-in caching support.
+          Use our <a href="https://github.com/sbomify/sbomify-action/pkgs/container/sbomify-action" class="text-[#8A7DFF] hover:text-white transition-colors">Docker image</a> directly in GitLab CI with built-in caching support.
         </p>
         <div class="bg-[#141035] rounded-lg p-4 overflow-x-auto text-sm text-gray-300 font-mono border border-[#37306B]">
 
 <pre><code>generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   cache:
     key: sbomify-cache
     paths:
       - .sbomify-cache/
   variables:
     SBOMIFY_CACHE_DIR: "${CI_PROJECT_DIR}/.sbomify-cache/sbomify"
-    TRIVY_CACHE_DIR: "${CI_PROJECT_DIR}/.sbomify-cache/trivy"
     SYFT_CACHE_DIR: "${CI_PROJECT_DIR}/.sbomify-cache/syft"
     LOCK_FILE: poetry.lock
     OUTPUT_FILE: sbom.cdx.json
@@ -90,10 +108,9 @@ description: "Seamlessly integrate SBOM generation, analysis, and enrichment int
         caches:
           - sbomify
         script:
-          - pipe: docker://sbomifyhub/sbomify-action:latest
+          - pipe: docker://ghcr.io/sbomify/sbomify-action:latest
             variables:
               SBOMIFY_CACHE_DIR: "${BITBUCKET_CLONE_DIR}/.sbomify-cache/sbomify"
-              TRIVY_CACHE_DIR: "${BITBUCKET_CLONE_DIR}/.sbomify-cache/trivy"
               SYFT_CACHE_DIR: "${BITBUCKET_CLONE_DIR}/.sbomify-cache/syft"
               LOCK_FILE: poetry.lock
               OUTPUT_FILE: sbom.cdx.json
@@ -111,10 +128,10 @@ definitions:
       <div class="bg-[#201B4C] rounded-2xl p-6 md:p-8 border border-[#37306B] shadow-sm hover:border-[#8A7DFF] transition-all" id="docker">
         <div class="flex flex-col md:flex-row md:items-center justify-between mb-6 gap-4">
           <span class="flex items-center gap-2 text-2xl font-bold text-white"><span class="text-[#8A7DFF]">{{< icon "docker" "w-8 h-8" >}}</span> Docker</span>
-          <a href="https://hub.docker.com/r/sbomifyhub/sbomify-action" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap" target="_blank">View on Docker Hub →</a>
+          <a href="https://github.com/sbomify/sbomify-action/pkgs/container/sbomify-action" class="text-sm font-semibold text-[#8A7DFF] hover:text-white transition-colors whitespace-nowrap" target="_blank">View on GHCR →</a>
         </div>
         <p class="text-gray-300 mb-6">
-          For any other CI/CD system, use our Docker image directly. All generators are pre-installed.
+          For any other CI/CD system, use our multi-arch (amd64 and arm64) Docker image directly. All generators are pre-installed.
         </p>
         <div class="bg-[#141035] rounded-lg p-4 overflow-x-auto text-sm text-gray-300 font-mono border border-[#37306B]">
 
@@ -126,13 +143,12 @@ docker run --rm \
   -v sbomify-cache:/cache \
   -w /github/workspace \
   -e SBOMIFY_CACHE_DIR=/cache/sbomify \
-  -e TRIVY_CACHE_DIR=/cache/trivy \
   -e SYFT_CACHE_DIR=/cache/syft \
   -e LOCK_FILE=/github/workspace/requirements.txt \
   -e OUTPUT_FILE=/github/workspace/sbom.cdx.json \
   -e UPLOAD=false \
   -e ENRICH=true \
-  sbomifyhub/sbomify-action</code></pre>
+  ghcr.io/sbomify/sbomify-action</code></pre>
 
         </div>
       </div>
@@ -170,7 +186,7 @@ sbomify-action</code></pre>
 <section>
     <div class="mb-10 text-center max-w-3xl mx-auto">
       <h2 class="text-3xl font-bold text-primaryText mb-4">Supported Ecosystems</h2>
-      <p class="text-lg text-secondaryText">Generate SBOMs from lockfiles across 14 languages, plus Docker images and Yocto/OpenEmbedded builds.</p>
+      <p class="text-lg text-secondaryText">Generate SBOMs from lockfiles across 14 ecosystems, plus Docker images and Yocto/OpenEmbedded builds.</p>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 mb-8">
@@ -291,7 +307,7 @@ sbomify-action</code></pre>
 <section>
     <div class="mb-10 text-center max-w-3xl mx-auto">
       <h2 class="text-3xl font-bold text-primaryText mb-4">SBOM Generators</h2>
-      <p class="text-lg text-secondaryText">Five generators with automatic fallback. The best tool for each ecosystem is selected automatically.</p>
+      <p class="text-lg text-secondaryText">Four generators with automatic fallback. The best tool for each ecosystem is selected automatically.</p>
     </div>
 
     <div class="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6 mb-8">
@@ -357,9 +373,15 @@ sbomify-action</code></pre>
       </div>
       <div class="bg-[#141035] rounded-2xl p-6 border border-[#37306B]">
         <h4 class="text-lg font-bold text-white mb-2">SPDX</h4>
-        <p class="text-gray-300 text-sm mb-3">Versions 2.2 and 2.3 via Syft, plus 3.0 via Yocto/OpenEmbedded. Validated against JSON schemas.</p>
+        <p class="text-gray-300 text-sm mb-3">Versions 2.2, 2.3, and 3.0.1 supported, validated against official schemas.</p>
         <code class="bg-[#201B4C] px-3 py-2 rounded text-[#8A7DFF] font-mono border border-[#37306B] inline-block text-sm">SBOM_FORMAT=spdx</code>
       </div>
+    </div>
+
+    <!-- Beyond SBOMs -->
+    <div class="bg-[#141035] rounded-2xl p-6 border border-[#37306B] mt-6">
+      <h4 class="text-lg font-bold text-white mb-2">Beyond SBOMs</h4>
+      <p class="text-gray-300 text-sm">The same pipeline can upload pre-authored <a href="/faq/what-vex-formats-does-sbomify-support/" class="text-[#8A7DFF] hover:text-white transition-colors">VEX</a>, <a href="/faq/what-is-a-cbom/" class="text-[#8A7DFF] hover:text-white transition-colors">CBOM</a>, and HBOM documents verbatim with <code class="text-[#8A7DFF]">BOM_TYPE=vex</code>, <code class="text-[#8A7DFF]">cbom</code>, or <code class="text-[#8A7DFF]">hbom</code>.</p>
     </div>
 
 </section>

--- a/content/features/trust-center.html
+++ b/content/features/trust-center.html
@@ -86,9 +86,11 @@ Turn transparency into a competitive advantage. Showcase your security posture w
             <div class="inline-block px-4 py-1 bg-[#201B4C]/5 text-[#201B4C] border border-[#201B4C]/10 rounded-full text-xs font-bold uppercase tracking-wider mb-6">Comprehensive Coverage</div>
             <h2 class="text-4xl font-bold text-[#201B4C] mb-6">Share More Than Just SBOMs</h2>
             <p class="text-lg text-secondaryText mb-8 leading-relaxed">
-                A complete trust center goes beyond dependencies. Provide a comprehensive view of your security posture by hosting all critical artifacts in one searchable library.
+                A complete trust center goes beyond dependencies. Provide a comprehensive view of your security posture by hosting all critical artifacts in one searchable library. Everything is also consumable programmatically via the Transparency Exchange API (TEA), and your security contact details can be published as an RFC 9116 security.txt.
             </p>
             <ul class="space-y-6">
+                {{< check-list-item title="VEX and CBOM Artifacts" description="Release-level VEX and CBOM downloads next to every SBOM, with a VEX-applied vulnerability posture card" >}}
+                {{< check-list-item title="Signed Artifacts" description="Signature and provenance badges so consumers can verify authenticity" >}}
                 {{< check-list-item title="Security Certifications" description="SOC 2, ISO 27001, and other audits" >}}
                 {{< check-list-item title="Penetration Test Reports" description="Share summaries or full reports securely" >}}
                 {{< check-list-item title="Compliance Attestations" description="Proof of regulatory adherence" >}}

--- a/content/guides/ci-cd.md
+++ b/content/guides/ci-cd.md
@@ -185,7 +185,7 @@ build:
 
 generate-sbom:
   stage: sbom
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: package-lock.json
     OUTPUT_FILE: sbom.cdx.json
@@ -210,7 +210,7 @@ include:
 
 generate-sbom:
   stage: test
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: package-lock.json
     OUTPUT_FILE: gl-sbom-report.cdx.json
@@ -230,7 +230,7 @@ generate-sbom:
 ```yaml
 container-sbom:
   stage: sbom
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   services:
     - docker:dind
   variables:
@@ -270,7 +270,7 @@ pipelines:
     - step:
         name: Generate SBOM
         script:
-          - pipe: docker://sbomifyhub/sbomify-action:latest
+          - pipe: docker://ghcr.io/sbomify/sbomify-action:latest
             variables:
               LOCK_FILE: package-lock.json
               OUTPUT_FILE: sbom.cdx.json
@@ -292,7 +292,7 @@ pipelines:
     - step:
         name: Generate and Upload SBOM
         script:
-          - pipe: docker://sbomifyhub/sbomify-action:latest
+          - pipe: docker://ghcr.io/sbomify/sbomify-action:latest
             variables:
               TOKEN: $SBOMIFY_TOKEN
               COMPONENT_ID: my-component
@@ -309,7 +309,7 @@ pipelines:
 pipeline {
     agent {
         docker {
-            image 'sbomifyhub/sbomify-action'
+            image 'ghcr.io/sbomify/sbomify-action'
         }
     }
 
@@ -348,7 +348,7 @@ pipeline {
         stage('Generate SBOM') {
             steps {
                 withCredentials([string(credentialsId: 'sbomify-token', variable: 'TOKEN')]) {
-                    docker.image('sbomifyhub/sbomify-action').inside {
+                    docker.image('ghcr.io/sbomify/sbomify-action').inside {
                         sh '''
                             export COMPONENT_ID="my-component"
                             export LOCK_FILE="package-lock.json"
@@ -375,7 +375,7 @@ version: 2.1
 jobs:
   generate-sbom:
     docker:
-      - image: sbomifyhub/sbomify-action
+      - image: ghcr.io/sbomify/sbomify-action
     steps:
       - checkout
       - run:
@@ -424,7 +424,7 @@ steps:
         -e COMPONENT_VERSION=$(Build.SourceVersion)
         -e UPLOAD=false
         -e ENRICH=true
-        sbomifyhub/sbomify-action
+        ghcr.io/sbomify/sbomify-action
 
   - publish: $(Build.SourcesDirectory)/sbom.cdx.json
     artifact: sbom

--- a/content/guides/cpp.md
+++ b/content/guides/cpp.md
@@ -109,7 +109,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For C/C++ with Conan, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For C/C++ with Conan, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -168,7 +168,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   before_script:
     - pip install conan
     - conan lock create .

--- a/content/guides/dart.md
+++ b/content/guides/dart.md
@@ -124,7 +124,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For Dart/Flutter, sbomify uses **cdxgen** or **Syft** under the hood (Trivy doesn't support Dart).
+For Dart/Flutter, sbomify uses **cdxgen** or **Syft** under the hood.
 
 **Standalone (no account needed):**
 
@@ -179,7 +179,7 @@ dart pub add --dev sbom
 
 Note: The `sbom` Dart package currently only supports SPDX format, not CycloneDX.
 
-Trivy currently has limited Dart support. Use cdxgen or Syft for CycloneDX output.
+Use cdxgen or Syft for CycloneDX output.
 
 When using these tools directly, you'll need to handle enrichment and augmentation separately.
 
@@ -187,7 +187,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: pubspec.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/docker.md
+++ b/content/guides/docker.md
@@ -98,7 +98,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For Docker images, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft. Use `DOCKER_IMAGE` instead of `LOCK_FILE`.
+For Docker images, sbomify uses **cdxgen** under the hood with fallback to Syft. Use `DOCKER_IMAGE` instead of `LOCK_FILE`.
 
 **Standalone (no account needed):**
 
@@ -138,12 +138,6 @@ DOCKER_IMAGE: ghcr.io/myorg/myapp:latest
 
 If you prefer to run SBOM generation tools manually:
 
-**Trivy:**
-
-```bash
-trivy image --format cyclonedx --output sbom.cdx.json myapp:latest
-```
-
 **Syft:**
 
 ```bash
@@ -168,7 +162,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   services:
     - docker:dind
   before_script:

--- a/content/guides/dotnet.md
+++ b/content/guides/dotnet.md
@@ -132,7 +132,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For .NET, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For .NET, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -187,19 +187,13 @@ npm install -g @cyclonedx/cdxgen
 cdxgen -t dotnet -o sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 When using these tools directly, you'll need to handle enrichment and augmentation separately.
 
 ### GitLab CI
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: packages.lock.json
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/elixir.md
+++ b/content/guides/elixir.md
@@ -238,7 +238,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: mix.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/go.md
+++ b/content/guides/go.md
@@ -146,7 +146,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For Go, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For Go, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -196,12 +196,6 @@ go install github.com/CycloneDX/cyclonedx-gomod/cmd/cyclonedx-gomod@latest
 cyclonedx-gomod mod -output sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 **Syft:**
 
 ```bash
@@ -214,7 +208,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: go.mod
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/java.md
+++ b/content/guides/java.md
@@ -210,19 +210,13 @@ plugins {
 gradle cyclonedxBom
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 When using these tools directly, you'll need to handle enrichment and augmentation separately.
 
 ### GitLab CI
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: pom.xml
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/javascript.md
+++ b/content/guides/javascript.md
@@ -169,12 +169,6 @@ npm install -g @cyclonedx/cdxgen
 cdxgen -o sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 **Syft:**
 
 ```bash
@@ -187,7 +181,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: package-lock.json
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/php.md
+++ b/content/guides/php.md
@@ -150,7 +150,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For PHP, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For PHP, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -198,19 +198,13 @@ npm install -g @cyclonedx/cdxgen
 cdxgen -t php -o sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 When using these tools directly, you'll need to handle enrichment and augmentation separately.
 
 ### GitLab CI
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: composer.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/python.md
+++ b/content/guides/python.md
@@ -102,12 +102,6 @@ cyclonedx-py environment --output-format json -o sbom.cdx.json
 
 This is the same tool sbomify uses under the hood. It reads from your installed environment and properly handles hashes.
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 **cdxgen:**
 
 ```bash
@@ -120,7 +114,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: uv.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/ruby.md
+++ b/content/guides/ruby.md
@@ -187,7 +187,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For Ruby, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For Ruby, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -235,12 +235,6 @@ npm install -g @cyclonedx/cdxgen
 cdxgen -t ruby -o sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 **Syft:**
 
 ```bash
@@ -253,7 +247,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: Gemfile.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/rust.md
+++ b/content/guides/rust.md
@@ -138,7 +138,7 @@ SBOM generation is the first step in the [SBOM lifecycle](/features/generate-col
 
 The [sbomify GitHub Action](https://github.com/sbomify/sbomify-action/) is a swiss army knife for SBOMs that automatically selects the best generation tool for your ecosystem, enriches the output with package metadata, and optionally augments it with your business information – all in one step.
 
-For Rust, sbomify uses **cdxgen** under the hood with fallback to Trivy and Syft.
+For Rust, sbomify uses **cdxgen** under the hood with fallback to Syft.
 
 **Standalone (no account needed):**
 
@@ -193,19 +193,13 @@ npm install -g @cyclonedx/cdxgen
 cdxgen -t rust -o sbom.cdx.json
 ```
 
-**Trivy:**
-
-```bash
-trivy fs --format cyclonedx --output sbom.cdx.json .
-```
-
 When using these tools directly, you'll need to handle enrichment and augmentation separately.
 
 ### GitLab CI
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: Cargo.lock
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/scala.md
+++ b/content/guides/scala.md
@@ -186,7 +186,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: build.sbt
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/swift.md
+++ b/content/guides/swift.md
@@ -221,7 +221,7 @@ When using these tools directly, you'll need to handle enrichment and augmentati
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   variables:
     LOCK_FILE: Package.resolved
     OUTPUT_FILE: sbom.cdx.json

--- a/content/guides/terraform.md
+++ b/content/guides/terraform.md
@@ -203,7 +203,7 @@ If you prefer to run SBOM generation tools manually:
 syft . -o cyclonedx-json=sbom.cdx.json
 ```
 
-Syft is currently the only widely-available open source tool that supports generating SBOMs from Terraform lockfiles. Trivy supports Terraform for IaC misconfiguration scanning but not for SBOM generation from `.terraform.lock.hcl`.
+Syft is currently the only widely-available open source tool that supports generating SBOMs from Terraform lockfiles.
 
 When using Syft directly, you'll need to handle enrichment and augmentation separately.
 
@@ -211,7 +211,7 @@ When using Syft directly, you'll need to handle enrichment and augmentation sepa
 
 ```yaml
 generate-sbom:
-  image: sbomifyhub/sbomify-action
+  image: ghcr.io/sbomify/sbomify-action
   before_script:
     - terraform init
   variables:

--- a/content/pricing.html
+++ b/content/pricing.html
@@ -58,6 +58,7 @@ faq:
             <li>Unlimited SBOMs & compliance documents</li>
             <li>Public documents only</li>
             <li><a href="/features/trust-center/">Public trust center</a></li>
+            <li>OSV vulnerability scanning (weekly re-scans)</li>
             <li>Manual exports only</li>
             <li>Basic compliance reporting</li>
             <li>Single user with community support</li>
@@ -95,8 +96,11 @@ faq:
             <li>Unlimited SBOMs & compliance documents</li>
             <li>Private documents with optional public sharing</li>
             <li><a href="/features/trust-center/">Custom trust center on your domain</a></li>
+            <li><a href="/faq/how-do-i-enable-tea-in-sbomify/">Transparency Exchange API (TEA)</a></li>
+            <li><a href="/faq/how-do-i-use-cra-compliance/">CRA Compliance Wizard</a></li>
+            <li><a href="/faq/how-do-i-enable-vulnerability-scanning/">Dependency Track integration</a></li>
             <li>Standard Integrations</li>
-            <li>Automated reports & vulnerability insights</li>
+            <li>Automated reports & vulnerability insights (daily re-scans)</li>
             <li>Team/role-based access</li>
             <li>Priority email support</li>
           </ul>

--- a/content/zero-to-hero.md
+++ b/content/zero-to-hero.md
@@ -106,8 +106,11 @@ Choose the option that fits your environment:
 **Setup wizard** (quickest)
 
 ```bash
-pip install sbomify-action
-sbomify-action init
+docker run --rm -it \
+  -v "$(pwd):/github/workspace" \
+  -w /github/workspace \
+  ghcr.io/sbomify/sbomify-action \
+  sbomify-action wizard
 ```
 
 The interactive [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/) scans your repo for lockfiles, creates your product and components in sbomify, registers [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/) (so you never store a token secret), and writes a ready-to-commit `.github/workflows/sboms.yml`.

--- a/content/zero-to-hero.md
+++ b/content/zero-to-hero.md
@@ -37,7 +37,7 @@ The [sbomify action](https://github.com/sbomify/sbomify-action) is **fully open 
 
 - Augmenting with supplier/author/manufacturer metadata
   - Data comes from your [sbomify profile](https://app.sbomify.com/) or a `sbomify.json` file in your repo
-- Enriching from **11 data sources** including:
+- Enriching from **12 data sources** including:
   - Pre-computed databases (LicenseDB, Lifecycle Database for EOL dates)
   - Native registries (PyPI, crates.io, pub.dev, Debian)
   - Aggregators (deps.dev, ecosyste.ms)
@@ -56,7 +56,7 @@ See [Integrations](/features/integrations/) for the full list of enrichment sour
 - **GitHub Actions** - Native integration
 - **Any CI/CD** - GitLab CI, Bitbucket Pipelines, Jenkins, CircleCI, etc.
 - **Python package** - `pip install sbomify-action` for standalone use
-- **Docker** - `sbomifyhub/sbomify-action` runs anywhere
+- **Docker** - `ghcr.io/sbomify/sbomify-action` runs anywhere
 
 ### Deployment Flexibility
 
@@ -103,7 +103,16 @@ sbomify supports all major ecosystems:
 
 Choose the option that fits your environment:
 
-**GitHub Actions** (quickest)
+**Setup wizard** (quickest)
+
+```bash
+pip install sbomify-action
+sbomify-action init
+```
+
+The interactive [setup wizard](/faq/how-do-i-use-the-sbomify-setup-wizard/) scans your repo for lockfiles, creates your product and components in sbomify, registers [OIDC trusted publishing](/faq/how-do-i-set-up-oidc-trusted-publishing/) (so you never store a token secret), and writes a ready-to-commit `.github/workflows/sboms.yml`.
+
+**GitHub Actions** (manual setup)
 
 ```yaml
 - name: Generate SBOM

--- a/layouts/home.llms.txt
+++ b/layouts/home.llms.txt
@@ -7,10 +7,12 @@ sbomify is a platform for generating, managing, and sharing Software Bill of Mat
 Key facts:
 
 - Artifact types supported: SBOM (Software Bill of Materials), CBOM (Cryptography Bill of Materials), VEX (Vulnerability Exploitability eXchange), attestations, and compliance documents
-- SBOM formats supported: CycloneDX, SPDX
-- Integrations: GitHub Actions, GitLab CI, Bitbucket Pipelines, Docker
-- Analysis tools: Google OSV, Dependency Track
-- Enrichment: the open-source sbomify-action (https://github.com/sbomify/sbomify-action) enriches SBOMs from 11 data sources: native package registries (PyPI, pub.dev, crates.io, Conan Center, Debian Sources), aggregators (deps.dev, ecosyste.ms), fallback sources (ClearlyDefined, Repology), and pre-computed license and lifecycle/EOL databases
+- SBOM formats supported: CycloneDX 1.3 through 1.7 and SPDX 2.2, 2.3, and 3.0.1 (JSON), validated against official schemas
+- VEX formats supported: CycloneDX VEX (JSON and XML), OpenVEX, and CSAF 2.0 VEX, with automatic format detection; VEX statements suppress findings in OSV and Dependency Track results
+- Integrations: GitHub Actions (including OIDC trusted publishing for tokenless uploads), GitLab CI, Bitbucket Pipelines, Docker
+- Onboarding: the interactive setup wizard (sbomify-action init) scans a repository, creates products and components, registers OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow
+- Analysis tools: Google OSV, Dependency Track, CISA KEV flagging, post-quantum cryptography (PQC) readiness assessment
+- Enrichment: the open-source sbomify-action (https://github.com/sbomify/sbomify-action) enriches SBOMs from 12 data sources: native package registries (PyPI, pub.dev, crates.io, Conan Center, Debian Sources), aggregators (deps.dev, ecosyste.ms), fallback sources (PURL extraction, ClearlyDefined, Repology), and pre-computed license and lifecycle/EOL databases
 - App: https://app.sbomify.com (support is handled via in-app support tickets)
 - Source code: https://github.com/sbomify
 

--- a/layouts/home.llms.txt
+++ b/layouts/home.llms.txt
@@ -10,7 +10,7 @@ Key facts:
 - SBOM formats supported: CycloneDX 1.3 through 1.7 and SPDX 2.2, 2.3, and 3.0.1 (JSON), validated against official schemas
 - VEX formats supported: CycloneDX VEX (JSON and XML), OpenVEX, and CSAF 2.0 VEX, with automatic format detection; VEX statements suppress findings in OSV and Dependency Track results
 - Integrations: GitHub Actions (including OIDC trusted publishing for tokenless uploads), GitLab CI, Bitbucket Pipelines, Docker
-- Onboarding: the interactive setup wizard (sbomify-action init) scans a repository, creates products and components, registers OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow
+- Onboarding: the interactive setup wizard (sbomify-action wizard, run via the Docker image) scans a repository, creates products and components, registers OIDC trusted publishing, and writes a ready-to-commit GitHub Actions workflow
 - Analysis tools: Google OSV, Dependency Track, CISA KEV flagging, post-quantum cryptography (PQC) readiness assessment
 - Enrichment: the open-source sbomify-action (https://github.com/sbomify/sbomify-action) enriches SBOMs from 12 data sources: native package registries (PyPI, pub.dev, crates.io, Conan Center, Debian Sources), aggregators (deps.dev, ecosyste.ms), fallback sources (PURL extraction, ClearlyDefined, Repology), and pre-computed license and lifecycle/EOL databases
 - App: https://app.sbomify.com (support is handled via in-app support tickets)

--- a/layouts/shortcodes/trust-center-artifacts.html
+++ b/layouts/shortcodes/trust-center-artifacts.html
@@ -37,7 +37,7 @@
                 <div class="font-bold text-[#201B4C] text-lg mb-1">Pentest Summary</div>
                 <div class="flex items-center gap-2">
                     <span class="text-xs font-medium text-gray-600 bg-gray-100 px-2 py-0.5 rounded-full border border-gray-200">Public</span>
-                    <span class="text-xs text-gray-400">Q4 2025</span>
+                    <span class="text-xs text-gray-400">Latest report</span>
                 </div>
             </div>
         </div>


### PR DESCRIPTION
## Summary

The product shipped ~5 months of features (multi-format VEX, CBOM/PQC, OIDC trusted publishing, the setup wizard, SPDX 3.0.1, Trivy removal, GHCR migration) that the site did not reflect. This PR audits recent PRs in `sbomify` and `sbomify-action` and updates all evergreen content to match.

## Corrections to stale claims

- **`faq/how-do-i-use-vex.md`** (largest rewrite): previously claimed VEX was CycloneDX-only, CSAF had to be uploaded as a regulatory document, and scanner suppression was "on the roadmap." Now documents CycloneDX (JSON/XML) + OpenVEX + CSAF 2.0 ingestion, shipped OSV/Dependency Track suppression, in-app triage with CISA KEV flags, self-VEX generation, DT triage sync, and release-level VEX downloads.
- **`features/integrations.html`**: OIDC-first GitHub example, setup wizard callout, `TRIVY_CACHE_DIR` removed from snippets, "Five generators" corrected to four, SPDX card now says 2.2/2.3/3.0.1, all image refs moved to `ghcr.io/sbomify/sbomify-action`, new "Beyond SBOMs" note for `BOM_TYPE` verbatim uploads.
- **All 16 guides**: removed false "fallback to Trivy" claims and standalone Trivy command sections; Docker Hub image refs swapped to GHCR.
- **Format claims unified everywhere**: CycloneDX 1.3-1.7, SPDX 2.2/2.3/3.0.1 (formats FAQ, integrations, llms.txt previously disagreed with each other).
- Fixed four broken `/compliance/ntia/` links and added an `aliases` redirect for external inbound links; fixed the "11 data sources" undercount; replaced the hardcoded "Q4 2025" pentest date in the Trust Center artifact mockup.

## New coverage

- **Four new FAQ pages**: `how-do-i-use-the-sbomify-setup-wizard` (weight 61), `how-do-i-set-up-oidc-trusted-publishing` (62), `what-vex-formats-does-sbomify-support` (66), `what-is-a-cbom` (68).
- **Homepage**: engineers persona card now highlights OIDC publishing and the wizard; Trust Center section mentions VEX/CBOM/TEA; Store/Analyze/Enrich notes VEX-aware scanning and CBOM/PQC readiness.
- **Pricing**: Business tier now lists TEA, CRA Compliance Wizard, Dependency Track, and daily re-scans (matching what the FAQs already said was Business-gated); Community notes weekly OSV scans; `is-sbomify-free.md` kept in sync.
- **Trust Center feature page**: VEX/CBOM artifacts, signature/provenance badges, TEA, and security.txt.
- **`layouts/home.llms.txt`**: format versions, VEX format list, OIDC, wizard, corrected 12-source enrichment count.

`assets/css/styles.css` is regenerated (one new Tailwind class from the wizard card).

## Verification

- `bun run lint:markdown` passes; `hugo --minify --environment production` builds clean (442 pages)
- All 27 FAQ pages render and appear in `/faq/index.json`; new pages slot correctly into the weight ordering
- Every added internal link resolves in the built site, including the `/compliance/ntia/` alias
- Greps confirm zero leftover `TRIVY_CACHE_DIR`, `sbomifyhub`, "fallback to Trivy", "on the roadmap", or "Five generators" outside blog posts
- No em-dashes introduced in prose

Note: lychee will hit the new external GHCR package link (`github.com/sbomify/sbomify-action/pkgs/container/sbomify-action`); it resolves, but GitHub occasionally rate-limits link checkers on `/pkgs/` URLs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)