### PR TITLE
docs: cover CalVer alongside SemVer in the SBOM versioning guide

### DIFF
--- a/content/guides/how-to-version-sboms.md
+++ b/content/guides/how-to-version-sboms.md
@@ -1,14 +1,16 @@
 ---
 
 url: /guides/how-to-version-sboms/
-title: "How to Version SBOMs - Semantic Versioning and Rolling Releases"
-description: "Learn best practices for versioning Software Bill of Materials. Guide covers Semantic Versioning, rolling releases, and linking SBOMs to your release process."
+title: "How to Version SBOMs - SemVer, CalVer, and Rolling Releases"
+description: "Learn best practices for versioning Software Bill of Materials. Guide covers Semantic Versioning, Calendar Versioning, rolling releases, and linking SBOMs to your release process."
 section: guides
 ---
 
 ## Introduction
 
-Depending on the type of software you are producing, versioning may or may not be straightforward. The gold standard for versioning is [Semantic Versioning](https://semver.org/). This approach works well for software that is released on a steady cadence (e.g., every month or even every few days). However, this model doesn't work as effectively for software delivered as a service, or anything with rolling releases. Many tech companies deploy new versions to production numerous times per day, and in this case, using a Semantic Versioning model creates a lot of friction.
+Depending on the type of software you are producing, versioning may or may not be straightforward. The most widely known scheme is [Semantic Versioning](https://semver.org/) (SemVer), which encodes API compatibility into the version number (`MAJOR.MINOR.PATCH`). It works well for libraries and tools where consumers care about breaking changes. It is not the only established scheme, though. [Calendar Versioning](https://calver.org/) (CalVer) derives version numbers from the release date instead, and is used by projects like Ubuntu (`24.04`) and pip. CalVer is a great fit when releases follow a time-based cadence rather than an API-compatibility contract, and it is what we use for sbomify itself. Either scheme gives you what matters for SBOMs: unique, ordered, human-readable version identifiers.
+
+Neither model works as effectively for software delivered as a service, or anything with rolling releases. Many tech companies deploy new versions to production numerous times per day, and in this case, maintaining any hand-assigned version number creates a lot of friction.
 
 Since SBOMs are directly related to software releases, the way you version and/or deploy your software will determine how you version your SBOM.
 
@@ -22,9 +24,11 @@ _"The Version is a supplier-defined identifier that specifies an update change i
 
 _If the Component does not have a unique semantic version available to declare, make sure that a cryptographic hash is provided for the Component. Be aware that this will not indicate the relative release of the Component to its predecessors and successors. As a minimum expectation, declare the version string as provided by the Supplier."_
 
-In short, they recommend using Semantic Versioning whenever possible. If you are creating your SBOMs in GitHub, you are likely using [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to manage releases. As such, you can leverage these for SBOM versioning automatically. For instance, if you are using our [GitHub Actions Module](https://github.com/sbomify/sbomify-action), you can set `SBOM_VERSION` to `${{ github.ref_name }}`, which will then automatically populate the corresponding version you created.
+While CISA states a preference for Semantic Versioning, note that their primary goal is "recording what is provided from the Supplier accurately." A CalVer version satisfies this just as well as a SemVer one: both are unique, ordered version strings that identify a specific release. What matters is that you use a well-defined scheme consistently, whichever one fits your release process.
 
-However, if you are not using Semantic Versioning, the document advises using a "cryptographic hash." Assuming your source code lives in a `git` repository, you can automatically derive a hash from there. If you are not using GitHub, you can use `git rev-parse HEAD` to get this. If you are using GitHub Actions (perhaps together with our GitHub Actions Module), you can then use `${{ github.sha }}` as a shorthand for this.
+If you are creating your SBOMs in GitHub, you are likely using [git tags](https://git-scm.com/book/en/v2/Git-Basics-Tagging) to manage releases, and this works identically whether your tags are SemVer (`v2.1.3`) or CalVer (`2026.07.1`). You can leverage these for SBOM versioning automatically. For instance, if you are using our [GitHub Actions Module](https://github.com/sbomify/sbomify-action), you can set `SBOM_VERSION` to `${{ github.ref_name }}`, which will then automatically populate the corresponding version you created.
+
+However, if you are not using a versioning scheme at all, the document advises using a "cryptographic hash." Assuming your source code lives in a `git` repository, you can automatically derive a hash from there. If you are not using GitHub, you can use `git rev-parse HEAD` to get this. If you are using GitHub Actions (perhaps together with our GitHub Actions Module), you can then use `${{ github.sha }}` as a shorthand for this.
 
 ## When to Release SBOMs
 
@@ -36,4 +40,4 @@ Regardless of whether this is a merge from one branch to another or a build/rele
 
 ## Conclusion
 
-If you're building SBOMs, please consider leveraging Semantic Versioning and git tags. This approach will help ensure that your SBOM is accurate and reproducible.
+If you're building SBOMs, please consider leveraging a well-defined versioning scheme, whether that is Semantic Versioning or Calendar Versioning, together with git tags. This approach will help ensure that your SBOM is accurate and reproducible.


### PR DESCRIPTION
## Summary

The [How to Version SBOMs](https://sbomify.com/guides/how-to-version-sboms/) guide presented SemVer as "the gold standard." It is not the only established scheme; sbomify itself uses CalVer. This PR:

- Introduces [Calendar Versioning](https://calver.org/) (CalVer) alongside SemVer in the intro, with Ubuntu and pip as examples, and notes that sbomify uses CalVer.
- Frames the two schemes by what they encode: SemVer for API-compatibility contracts, CalVer for time-based release cadences. Either gives SBOMs what they need: unique, ordered, human-readable version identifiers.
- Clarifies after the CISA quote that their primary goal is accurately recording the supplier's version string, which CalVer satisfies just as well as SemVer, and that git-tag-based automation (`SBOM_VERSION: ${{ github.ref_name }}`) works identically for both.
- Scopes the "cryptographic hash" fallback to teams using no versioning scheme at all, rather than to anyone not using SemVer.
- Updates the page title and meta description to mention CalVer (URL unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)