### PR TITLE
docs: correct CMMC Rev 2 baseline and add rollout timeline to NIST 800-171 page

### DIFF
--- a/content/compliance/nist-800-171.md
+++ b/content/compliance/nist-800-171.md
@@ -2,7 +2,7 @@
 
 url: /compliance/nist-800-171/
 title: "NIST SP 800-171 SBOM Requirements: Protecting CUI in Software Supply Chains"
-description: "How NIST SP 800-171 Rev 3 supply chain and component inventory controls relate to SBOM requirements for organizations handling Controlled Unclassified Information."
+description: "How NIST SP 800-171 Rev 3 supply chain and component inventory controls relate to SBOM requirements for organizations handling Controlled Unclassified Information. Includes the CMMC phased rollout timeline through 2028."
 section: compliance
 tldr: "NIST SP 800-171 protects Controlled Unclassified Information (CUI) in nonfederal systems and is required for DoD contractors via CMMC. Its supply chain risk management requirements align with SBOM practices for documenting and verifying software components."
 faq:
@@ -13,7 +13,9 @@ faq:
   - question: "What is the difference between NIST 800-171 and NIST 800-53?"
     answer: "NIST SP 800-53 is the comprehensive security control catalog for federal information systems, containing over 1,000 controls across 20 families. NIST SP 800-171 is a derived subset of 97 requirements tailored for protecting CUI in nonfederal systems. 800-171 Rev 3 controls map directly to 800-53 Rev 5 controls from the moderate baseline."
   - question: "What is CMMC and how does it relate to NIST 800-171?"
-    answer: "CMMC (Cybersecurity Maturity Model Certification) is the DoD's program for verifying that contractors have implemented NIST 800-171 requirements. CMMC Level 2 directly maps to the 97 requirements in NIST 800-171. Organizations seeking DoD contracts that involve CUI must achieve CMMC Level 2 certification through a third-party assessment."
+    answer: "CMMC (Cybersecurity Maturity Model Certification) is the DoD's program for verifying that contractors have implemented NIST 800-171 requirements. CMMC Level 2 assessments are currently conducted against the 110 requirements of NIST 800-171 Revision 2, because a DoD class deviation keeps DFARS 252.204-7012 pinned to Rev 2 until the CMMC program transitions to Rev 3 through rulemaking. Organizations seeking DoD contracts that involve CUI must achieve CMMC Level 2 through a third-party assessment."
+  - question: "When do I need CMMC certification?"
+    answer: "CMMC requirements are being phased into DoD contracts under 32 CFR 170.3. Phase 1 began on November 10, 2025, when the DFARS acquisition rule took effect and self-assessment requirements started appearing in solicitations. Phase 2 begins on November 10, 2026, when CMMC Level 2 third-party (C3PAO) certification requirements start appearing in applicable solicitations. Full implementation across all applicable DoD contracts arrives with Phase 4 on November 10, 2028."
   - question: "What changed in NIST 800-171 Rev 3?"
     answer: "The most significant changes include the addition of three new control families (Planning, System and Services Acquisition, and Supply Chain Risk Management), full alignment with NIST SP 800-53 Rev 5, the introduction of 88 Organization-Defined Parameters across 49 requirements, and an increase to 422 assessment determination statements. The new Supply Chain Risk Management family (03.17) is the most relevant addition for SBOM requirements."
 ---
@@ -35,6 +37,8 @@ faq:
 
 NIST SP 800-171 is most commonly encountered through Department of Defense (DoD) contracts. The DFARS clause 252.204-7012 requires DoD contractors to implement NIST 800-171, and the [Cybersecurity Maturity Model Certification](https://dodcio.defense.gov/CMMC/) (CMMC) program uses 800-171 as the basis for its Level 2 assessment.
 
+> **Which revision applies?** Rev 3 is NIST's current publication, but DoD contracts do not yet require it. [Class Deviation 2024-O0013](https://www.acq.osd.mil/dpap/policy/policyvault/USA001074-24-DPC.pdf) pins DFARS 252.204-7012 compliance to **Rev 2**, and CMMC assessments under [32 CFR Part 170](https://www.ecfr.gov/current/title-32/subtitle-A/chapter-I/subchapter-G/part-170) are conducted against Rev 2's 110 requirements. The deviation remains in effect until rescinded, and moving CMMC to Rev 3 requires formal rulemaking. Contractors should comply with Rev 2 today while tracking Rev 3, since its supply chain controls signal where DoD requirements are heading.
+
 While NIST 800-171 does not explicitly use the term "SBOM," Revision 3 introduced three new control families – including Supply Chain Risk Management – that create strong requirements for the kind of software component transparency that SBOMs provide.
 
 ## Relationship to NIST SP 800-53
@@ -48,6 +52,8 @@ NIST SP 800-171 Rev 3 derives its controls from [NIST SP 800-53 Rev 5](/complian
 | **NIST SP 800-172**       | Enhanced requirements for high-value CUI          | CMMC Level 3 organizations                | 35 enhanced requirements           |
 
 Understanding this hierarchy matters because some 800-53 controls highly relevant to SBOMs (such as SR-4, Provenance) are not directly included in 800-171 but may be required through DoD supplemental guidance or CMMC Level 3 assessments.
+
+> **Note:** NIST published [SP 800-172 Rev 3](https://csrc.nist.gov/pubs/sp/800/172/r3/final) in May 2026, together with the SP 800-172A Rev 3 assessment procedures. CMMC Level 3 remains anchored to the requirements DoD selected from the 2021 version of 800-172 until the program adopts the revision through rulemaking.
 
 ## Key Control Families Relevant to SBOMs
 
@@ -107,9 +113,22 @@ The [Cybersecurity Maturity Model Certification](https://dodcio.defense.gov/CMMC
 - **Level 2** – Full NIST SP 800-171 implementation (third-party assessment by a C3PAO)
 - **Level 3** – NIST SP 800-171 plus selected 800-172 enhanced requirements (government-led assessment)
 
-For CMMC Level 2 assessments, assessors evaluate 422 determination statements derived from the 97 NIST 800-171 Rev 3 requirements. The DoD CIO publishes [Organization-Defined Parameters](https://dodcio.defense.gov/CMMC/) (ODPs) that specify values for customizable fields in the 800-171 controls.
+CMMC Level 2 assessments are currently conducted against the **110 requirements of NIST 800-171 Rev 2**, using the assessment objectives in NIST SP 800-171A. The 97 requirements and 422 determination statements of Rev 3 will only apply to CMMC once DoD transitions the program to Rev 3 through formal rulemaking. The DoD CIO publishes [Organization-Defined Parameters](https://dodcio.defense.gov/CMMC/) (ODPs) that specify values for customizable fields in the 800-171 Rev 3 controls ahead of that transition.
 
 Organizations preparing for CMMC should treat SBOM generation and management as supporting evidence for multiple controls, particularly 03.17.01 (Supply Chain Risk Management Plan), 03.04.10 (System Component Inventory), and 03.14.01 (Flaw Remediation).
+
+### CMMC Rollout Timeline
+
+CMMC requirements are being phased into DoD contracts under [32 CFR 170.3](https://www.ecfr.gov/current/title-32/subtitle-A/chapter-I/subchapter-G/part-170) and the [DFARS acquisition final rule](https://www.federalregister.gov/documents/2025/09/10/2025-17359/defense-federal-acquisition-regulation-supplement-assessing-contractor-implementation-of) (effective 10 November 2025, adding contract clause 252.204-7021 and solicitation provision 252.204-7025):
+
+| Phase   | Start Date       | What Applies                                                                                                                   |
+| ------- | ---------------- | ------------------------------------------------------------------------------------------------------------------------------ |
+| Phase 1 | 10 November 2025 | CMMC clauses appear in solicitations; Level 1 and Level 2 self-assessments required, at DoD's discretion                       |
+| Phase 2 | 10 November 2026 | CMMC Level 2 third-party (C3PAO) certification requirements begin appearing in applicable solicitations                        |
+| Phase 3 | 10 November 2027 | Level 2 certification requirements broaden; Level 3 (government-led DIBCAC) assessments introduced                             |
+| Phase 4 | 10 November 2028 | Full implementation: all applicable DoD contracts involving FCI or CUI include the required CMMC level as a condition of award |
+
+The practical takeaway: contractors handling CUI who will need a Level 2 certification should be assessment-ready before Phase 2 begins in November 2026. Evidence for the supply chain and component inventory controls, including SBOMs for the software you build and buy, takes time to put in place.
 
 ## Key Changes from Rev 2 to Rev 3
 
@@ -149,9 +168,13 @@ If you sell software to organizations that handle CUI:
 
 - [NIST SP 800-171 Rev 3](https://csrc.nist.gov/pubs/sp/800/171/r3/final) – Full publication
 - [NIST SP 800-171A Rev 3](https://csrc.nist.gov/pubs/sp/800/171/a/r3/final) – Assessment procedures
+- [NIST SP 800-172 Rev 3](https://csrc.nist.gov/pubs/sp/800/172/r3/final) – Enhanced requirements (May 2026)
 - [NIST SP 800-53 Rev 5](https://csrc.nist.gov/pubs/sp/800/53/r5/upd1/final) – Parent control catalog
 - [CMMC Program](https://dodcio.defense.gov/CMMC/) – DoD certification program
+- [32 CFR Part 170](https://www.ecfr.gov/current/title-32/subtitle-A/chapter-I/subchapter-G/part-170) – CMMC Program rule, including the phased implementation in 170.3
+- [DFARS Final Rule (Case 2019-D041)](https://www.federalregister.gov/documents/2025/09/10/2025-17359/defense-federal-acquisition-regulation-supplement-assessing-contractor-implementation-of) – Acquisition rule adding CMMC clauses to contracts, effective 10 November 2025
 - [DFARS 252.204-7012](https://www.acquisition.gov/dfars/252.204-7012-safeguarding-covered-defense-information-and-cyber-incident-reporting.html) – Contract clause requiring 800-171 implementation
+- [Class Deviation 2024-O0013, Revision 1](https://www.acq.osd.mil/dpap/policy/policyvault/USA001074-24-DPC.pdf) – Pins DFARS 252.204-7012 to NIST SP 800-171 Rev 2
 
 ---
 
@@ -171,7 +194,11 @@ NIST 800-171 Rev 3 does not explicitly use the term "SBOM." However, several con
 
 ### What is CMMC and how does it relate to NIST 800-171?
 
-CMMC (Cybersecurity Maturity Model Certification) is the DoD's program for verifying that contractors have implemented NIST 800-171 requirements. CMMC Level 2 directly maps to the 97 requirements in NIST 800-171. Organizations seeking DoD contracts that involve CUI must achieve CMMC Level 2 certification through a third-party assessment.
+CMMC (Cybersecurity Maturity Model Certification) is the DoD's program for verifying that contractors have implemented NIST 800-171 requirements. CMMC Level 2 assessments are currently conducted against the 110 requirements of NIST 800-171 Revision 2, because a DoD class deviation keeps DFARS 252.204-7012 pinned to Rev 2 until the CMMC program transitions to Rev 3 through rulemaking. Organizations seeking DoD contracts that involve CUI must achieve CMMC Level 2 through a third-party assessment.
+
+### When do I need CMMC certification?
+
+CMMC requirements are being phased into DoD contracts under 32 CFR 170.3. Phase 1 began on November 10, 2025, when the DFARS acquisition rule took effect and self-assessment requirements started appearing in solicitations. Phase 2 begins on November 10, 2026, when CMMC Level 2 third-party (C3PAO) certification requirements start appearing in applicable solicitations. Full implementation across all applicable DoD contracts arrives with Phase 4 on November 10, 2028.
 
 ### What changed in NIST 800-171 Rev 3?
 


### PR DESCRIPTION
## Summary

Refreshes the NIST SP 800-171 compliance page with current CMMC program status, all cited to official sources only (NIST CSRC, eCFR, Federal Register, acq.osd.mil):

### Factual correction

The page previously stated that CMMC Level 2 assessments evaluate "422 determination statements derived from the 97 NIST 800-171 Rev 3 requirements." That is not yet true: [Class Deviation 2024-O0013](https://www.acq.osd.mil/dpap/policy/policyvault/USA001074-24-DPC.pdf) pins DFARS 252.204-7012 to **Rev 2**, and CMMC assessments under 32 CFR Part 170 run against Rev 2's 110 requirements. Rev 3 figures apply only after DoD transitions the program through rulemaking. Corrected in the body and both FAQ locations.

### New content

- **"Which revision applies?" callout** in the Overview explaining the Rev 2 / Rev 3 split
- **CMMC Rollout Timeline** section covering the DFARS acquisition final rule (effective 10 November 2025, clauses 252.204-7021/7025) and the four phases from 32 CFR 170.3: Phase 1 (Nov 2025, self-assessments), Phase 2 (Nov 2026, Level 2 C3PAO certifications), Phase 3 (Nov 2027), Phase 4 full implementation (Nov 2028), with an SBOM-readiness takeaway ahead of Phase 2
- **New FAQ**: "When do I need CMMC certification?" (frontmatter + body)
- **SP 800-172 Rev 3** note (published May 2026): CMMC Level 3 stays anchored to the 2021 selection until rulemaking
- Official Sources expanded with 32 CFR Part 170, the DFARS final rule, the class deviation memo, and SP 800-172 Rev 3
- Meta description now mentions the rollout timeline; title unchanged to avoid SEO churn

## Verification

- `bun run lint:markdown` passes (dprint)
- `hugo --minify --environment production` builds cleanly; new sections render on `/compliance/nist-800-171/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)