### PR TITLE
docs: cite official records and precise dates on EO 14028 page

### DIFF
--- a/content/compliance/eo-14028.md
+++ b/content/compliance/eo-14028.md
@@ -39,11 +39,11 @@ EO 14028 **does not specify SBOM field-level requirements**. Instead, it defers 
 
 EO 14028 itself has **not been rescinded** and remains in effect. However, the implementing guidance has changed significantly:
 
-- **EO 14144 (January 2025):** The Biden administration issued EO 14144 to strengthen EO 14028 with more rigorous third-party attestation requirements, including mandatory machine-readable attestations submitted to CISA, high-level artifacts such as SBOMs, and centralized validation.
+- **[EO 14144](https://www.federalregister.gov/documents/2025/01/17/2025-01470/strengthening-and-promoting-innovation-in-the-nations-cybersecurity) (16 January 2025):** The Biden administration issued EO 14144 to strengthen EO 14028 with more rigorous third-party attestation requirements, including mandatory machine-readable attestations submitted to CISA, high-level artifacts such as SBOMs, and centralized validation.
 
-- **EO 14306 (June 2025):** The Trump administration rescinded key portions of EO 14144, removing the enhanced attestation mandates, the requirement for vendors to provide SBOMs as "high-level artifacts," the CISA centralized validation role, and several other provisions. NIST guidance updates (SP 800-53, SP 800-218) and FedRAMP requirements were retained.
+- **[EO 14306](https://www.whitehouse.gov/presidential-actions/2025/06/sustaining-select-efforts-to-strengthen-the-nations-cybersecurity-and-amending-executive-order-13694-and-executive-order-14144/) (6 June 2025):** The Trump administration rescinded key portions of EO 14144, removing the enhanced attestation mandates, the requirement for vendors to provide SBOMs as "high-level artifacts," the CISA centralized validation role, and several other provisions. NIST guidance updates (SP 800-53, SP 800-218) and FedRAMP requirements were retained. EO 14028's own text was left intact.
 
-- **OMB Memorandum M-26-05 (January 2026):** OMB rescinded Memorandums M-22-18 and M-23-16, which had required agencies to obtain standardized self-attestation forms from software vendors. The new approach allows each agency to develop its own risk-based assurance processes. The universal attestation requirement is now **optional** – agencies may use CISA's common form at their discretion. Notably, M-26-05 states that agencies adopting contractual terms for cloud service providers should specify that the producer must provide an **SBOM of the runtime production environment upon request**.
+- **[OMB Memorandum M-26-05](https://www.whitehouse.gov/wp-content/uploads/2026/01/M-26-05-Adopting-a-Risk-based-Approach-to-Software-and-Hardware-Security.pdf) (23 January 2026):** OMB rescinded Memorandums M-22-18 and M-23-16, which had required agencies to obtain standardized self-attestation forms from software vendors. The new approach allows each agency to develop its own risk-based assurance processes. The universal attestation requirement is now **optional** – agencies may use CISA's common form at their discretion. Notably, M-26-05 states that agencies adopting contractual terms for cloud service providers should specify that the producer must provide an **SBOM of the runtime production environment upon request**.
 
 ### What This Means in Practice
 
@@ -57,10 +57,11 @@ The shift is from a centralized, one-size-fits-all attestation mandate to a dece
 
 ## Official Sources
 
-- [Executive Order 14028 – Improving the Nation's Cybersecurity (2021)](https://www.gsa.gov/technology/government-it-initiatives/cybersecurity/executive-order-14028)
-- [OMB Memorandum M-26-05 (January 2026)](https://www.whitehouse.gov/omb/information-for-agencies/memoranda/)
-- [OMB Rescinds Biden-Era Software Security Requirements (Davis Wright Tremaine analysis)](https://www.dwt.com/blogs/privacy--security-law-blog/2026/02/omb-changes-course-on-software-security)
-- [Trump Reverses Key Directives of Biden Cyber Executive Order (Davis Wright Tremaine analysis)](https://www.dwt.com/blogs/privacy--security-law-blog/2025/06/trump-cyber-order-changes-biden-eo-14144)
+- [Executive Order 14028 – Improving the Nation's Cybersecurity](https://www.federalregister.gov/documents/2021/05/17/2021-10460/improving-the-nations-cybersecurity) (Federal Register, May 2021)
+- [GSA: Executive Order 14028 implementation](https://www.gsa.gov/technology/government-it-initiatives/cybersecurity/executive-order-14028)
+- [Executive Order 14144 – Strengthening and Promoting Innovation in the Nation's Cybersecurity](https://www.federalregister.gov/documents/2025/01/17/2025-01470/strengthening-and-promoting-innovation-in-the-nations-cybersecurity) (Federal Register, January 2025)
+- [Executive Order 14306 – Sustaining Select Efforts to Strengthen the Nation's Cybersecurity](https://www.whitehouse.gov/presidential-actions/2025/06/sustaining-select-efforts-to-strengthen-the-nations-cybersecurity-and-amending-executive-order-13694-and-executive-order-14144/) (White House, June 2025)
+- [OMB Memorandum M-26-05 – Adopting a Risk-based Approach to Software and Hardware Security](https://www.whitehouse.gov/wp-content/uploads/2026/01/M-26-05-Adopting-a-Risk-based-Approach-to-Software-and-Hardware-Security.pdf) (January 2026)
 
 ---
 


### PR DESCRIPTION
## Summary

The EO 14028 page's policy content was already current (EO 14144, EO 14306, M-26-05 all covered), so this PR is a source-hygiene pass to keep the page on official references only:

- **Official Sources**: replaced two law-firm blog citations with the canonical records - Federal Register entries for EO 14028 (2021) and EO 14144 (2025), the White House presidential action for EO 14306 (2025), and the direct M-26-05 PDF (the previous link pointed at OMB's generic memoranda listing)
- **Policy Updates section**: linked each order/memo to its official record inline, added precise issue dates (EO 14144: 16 January 2025; EO 14306: 6 June 2025; M-26-05: 23 January 2026), and noted explicitly that EO 14306 left EO 14028's own text intact
- Verified against 2026 sources that nothing newer has amended EO 14028

## Verification

- `bun run lint:markdown` passes (dprint)
- `hugo --minify --environment production` builds cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)