### PR TITLE
Add Chat on Slack sales CTA

### DIFF
--- a/assets/css/styles.css
+++ b/assets/css/styles.css
@@ -1384,6 +1384,10 @@ a.button:hover {
   gap: 0.5rem;
 }
 
+.gap-2\.5 {
+  gap: 0.625rem;
+}
+
 .gap-3 {
   gap: 0.75rem;
 }

--- a/content/_index.html
+++ b/content/_index.html
@@ -24,6 +24,10 @@ keywords: trust center, SBOM, Security Artifact Hub, CRA compliance, NTIA compli
                         <svg aria-hidden="true" class="w-4 h-4 motion-safe:group-hover:translate-x-1 transition-transform duration-200" fill="none" stroke="currentColor" stroke-width="2.5" stroke-linecap="round" stroke-linejoin="round" viewBox="0 0 24 24"><path d="M5 12h14M13 5l7 7-7 7"/></svg>
                     </a>
                     <a href="https://app.sbomify.com/enterprise-contact/" class="inline-flex items-center justify-center px-8 py-4 bg-white/5 border border-white/15 hover:bg-white/10 hover:border-white/25 text-white rounded-full font-semibold text-lg backdrop-blur-sm motion-safe:hover:-translate-y-0.5 transition-[background-color,border-color,transform] duration-200">Contact Us</a>
+                    <a href="https://sbomify.com/slack" target="_blank" rel="noopener noreferrer" class="inline-flex items-center justify-center gap-2.5 px-8 py-4 bg-white/5 border border-white/15 hover:bg-white/10 hover:border-white/25 text-white rounded-full font-semibold text-lg backdrop-blur-sm motion-safe:hover:-translate-y-0.5 transition-[background-color,border-color,transform] duration-200" onclick="posthog.capture('cta_click', { location: 'hero', label: 'Chat on Slack', destination: 'https://sbomify.com/slack' })">
+                        {{< icon "slack" "w-5 h-5" >}}
+                        Chat on Slack
+                    </a>
                 </div>
             </div>
 

--- a/content/pricing.html
+++ b/content/pricing.html
@@ -109,6 +109,7 @@ faq:
       <div class="card-footer">
         <a href="https://app.sbomify.com" class="cta-button" onclick="posthog.capture('cta_click', { location: 'pricing', label: 'Business Plan Signup' })">Start 14-day free trial</a>
         <a href="https://app.sbomify.com/enterprise-contact/" class="block mt-3 text-sm text-gray-300 hover:text-white underline underline-offset-4 decoration-gray-500 hover:decoration-white transition-colors" onclick="posthog.capture('cta_click', { location: 'pricing', label: 'Business Plan Talk to Sales' })">Or talk to sales &rarr;</a>
+        <a href="https://sbomify.com/slack" target="_blank" rel="noopener noreferrer" class="block mt-2 text-sm text-gray-300 hover:text-white underline underline-offset-4 decoration-gray-500 hover:decoration-white transition-colors" onclick="posthog.capture('cta_click', { location: 'pricing', label: 'Business Plan Chat on Slack', destination: 'https://sbomify.com/slack' })">Or chat with us on Slack &rarr;</a>
       </div>
     </div>
 
@@ -145,6 +146,7 @@ faq:
       </div>
       <div class="card-footer">
         <a href="https://app.sbomify.com/enterprise-contact/" class="cta-button" onclick="posthog.capture('cta_click', { location: 'pricing', label: 'Enterprise Plan Contact' })">Contact Us</a>
+        <a href="https://sbomify.com/slack" target="_blank" rel="noopener noreferrer" class="block mt-3 text-sm text-gray-300 hover:text-white underline underline-offset-4 decoration-gray-500 hover:decoration-white transition-colors" onclick="posthog.capture('cta_click', { location: 'pricing', label: 'Enterprise Plan Chat on Slack', destination: 'https://sbomify.com/slack' })">Or chat with us on Slack &rarr;</a>
       </div>
     </div>
 

--- a/data/main.yml
+++ b/data/main.yml
@@ -16,4 +16,4 @@ social:
   x: https://x.com/sbomify
   linkedIn: https://www.linkedin.com/company/sbomify
   github: https://github.com/sbomify
-  slack: https://join.slack.com/t/sbomify/shared_invite/zt-3na54pa1f-MXrFWhotmZr0YxXc8sABTw
+  slack: https://sbomify.com/slack

--- a/layouts/partials/icon.html
+++ b/layouts/partials/icon.html
@@ -11,6 +11,7 @@
   "x-twitter" "brands/x-twitter.svg"
   "mastodon" "brands/mastodon.svg"
   "github" "brands/github.svg"
+  "slack" "brands/slack.svg"
   "globe" "solid/globe.svg"
   "podcast" "solid/podcast.svg"
   "python" "brands/python.svg"


### PR DESCRIPTION
## Summary
- Add a **Chat on Slack** button (with inlined Slack logo) to the homepage hero next to "Contact Us"
- Add **"Or chat with us on Slack →"** links to the Business and Enterprise pricing cards
- Route all Slack links, including the footer social icon, through the stable `https://sbomify.com/slack` redirect instead of the raw `join.slack.com` invite link, so when the invite link rotates (Slack caps each link at 400 uses) only the CDN redirect rule needs updating
- Register Font Awesome's Slack brand icon in the `icon` partial so `{{</* icon "slack" */>}}` works site-wide

## Performance
- Icon SVG is inlined at Hugo build time: no extra requests, no new JS beyond the inline PostHog `cta_click` handlers already used by other CTAs
- Rebuilt Tailwind CSS included

## Testing
- `bun run build:css` and `hugo --minify --environment production` both pass
- Verified rendered homepage and pricing pages contain the new CTAs and no `join.slack.com` references remain in the output

🤖 Generated with [Claude Code](https://claude.com/claude-code)